### PR TITLE
Add utility to extract first step from phase docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# CLI Wrapper Utilities
+
+This repository contains helper utilities for the CLI Wrapper project.
+
+## `phasefirst` Command
+
+The `phasefirst` command extracts the first bullet from the **Detailed Steps**
+section of each phase document under `docs/phases`. It outputs the result as
+formatted JSON.
+
+### Building
+
+```
+go build ./cmd/phasefirst
+```
+
+### Running
+
+```
+./phasefirst
+```
+
+The command writes operational logs to `sentinel.log` in `/var/log` on Unix or
+`C:\Temp` on Windows. Logs are stored in JSON with automatic rotation.
+
+### Testing
+
+Run unit tests with:
+
+```
+go vet ./...
+go test -race ./...
+```
+

--- a/cmd/phasefirst/main.go
+++ b/cmd/phasefirst/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"cli-wrapper/internal/logging"
+	"cli-wrapper/internal/phases"
+)
+
+func main() {
+	logger, err := logging.New()
+	if err != nil {
+		log.Fatalf("failed to init logger: %v", err)
+	}
+	defer logger.Close()
+
+	steps, err := phases.PhaseFirstSteps("docs/phases")
+	if err != nil {
+		logger.Error(fmt.Sprintf("collect steps: %v", err))
+		log.Fatal(err)
+	}
+	data, err := json.MarshalIndent(steps, "", "  ")
+	if err != nil {
+		logger.Error(fmt.Sprintf("marshal output: %v", err))
+		log.Fatal(err)
+	}
+	logger.Info("extracted first steps successfully")
+	fmt.Println(string(data))
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module cli-wrapper
+
+go 1.24

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -1,0 +1,162 @@
+package logging
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"time"
+)
+
+type rotateWriter struct {
+	path       string
+	file       *os.File
+	maxSize    int64
+	maxBackups int
+	maxAge     time.Duration
+}
+
+func newRotateWriter(path string, maxSize int64, maxBackups int, maxAge time.Duration) (*rotateWriter, error) {
+	if maxSize <= 0 || maxBackups < 0 {
+		return nil, errors.New("invalid rotation parameters")
+	}
+	rw := &rotateWriter{
+		path:       path,
+		maxSize:    maxSize,
+		maxBackups: maxBackups,
+		maxAge:     maxAge,
+	}
+	if err := rw.open(); err != nil {
+		return nil, err
+	}
+	return rw, nil
+}
+
+func (w *rotateWriter) open() error {
+	dir := filepath.Dir(w.path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create log dir: %w", err)
+	}
+	f, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("open log file: %w", err)
+	}
+	w.file = f
+	return nil
+}
+
+func (w *rotateWriter) Write(p []byte) (int, error) {
+	info, err := w.file.Stat()
+	if err != nil {
+		return 0, fmt.Errorf("stat log file: %w", err)
+	}
+	if info.Size()+int64(len(p)) > w.maxSize {
+		if err := w.rotate(); err != nil {
+			return 0, err
+		}
+	}
+	return w.file.Write(p)
+}
+
+func (w *rotateWriter) rotate() error {
+	if err := w.file.Close(); err != nil {
+		return fmt.Errorf("close log file: %w", err)
+	}
+	ts := time.Now().UTC().Format("20060102T150405Z")
+	rotated := fmt.Sprintf("%s-%s", w.path, ts)
+	if err := os.Rename(w.path, rotated); err != nil {
+		return fmt.Errorf("rotate log file: %w", err)
+	}
+	if err := w.cleanup(); err != nil {
+		return err
+	}
+	return w.open()
+}
+
+func (w *rotateWriter) cleanup() error {
+	files, err := filepath.Glob(w.path + "-*")
+	if err != nil {
+		return fmt.Errorf("glob backups: %w", err)
+	}
+	sort.Slice(files, func(i, j int) bool {
+		return files[i] > files[j]
+	})
+	now := time.Now().UTC()
+	valid := files[:0]
+	for _, f := range files {
+		info, err := os.Stat(f)
+		if err != nil {
+			continue
+		}
+		if now.Sub(info.ModTime()) > w.maxAge {
+			os.Remove(f)
+			continue
+		}
+		valid = append(valid, f)
+	}
+	if len(valid) > w.maxBackups {
+		remove := valid[w.maxBackups:]
+		for _, f := range remove {
+			os.Remove(f)
+		}
+	}
+	return nil
+}
+
+func (w *rotateWriter) Close() error {
+	return w.file.Close()
+}
+
+type Logger struct {
+	writer io.WriteCloser
+}
+
+type logEntry struct {
+	Timestamp string `json:"timestamp"`
+	Level     string `json:"level"`
+	Message   string `json:"message"`
+}
+
+func New() (*Logger, error) {
+	path := "/var/log/sentinel.log"
+	if runtime.GOOS == "windows" {
+		path = filepath.Join(os.Getenv("SystemDrive"), "Temp", "sentinel.log")
+	}
+	rw, err := newRotateWriter(path, 20*1024*1024, 5, 30*24*time.Hour)
+	if err != nil {
+		return nil, err
+	}
+	return &Logger{writer: rw}, nil
+}
+
+func (l *Logger) log(level, msg string) error {
+	entry := logEntry{
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Level:     level,
+		Message:   msg,
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("marshal log: %w", err)
+	}
+	if _, err := l.writer.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("write log: %w", err)
+	}
+	return nil
+}
+
+func (l *Logger) Info(msg string) error {
+	return l.log("INFO", msg)
+}
+
+func (l *Logger) Error(msg string) error {
+	return l.log("ERROR", msg)
+}
+
+func (l *Logger) Close() error {
+	return l.writer.Close()
+}

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -1,0 +1,29 @@
+package logging
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLoggerWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sentinel.log")
+	rw, err := newRotateWriter(path, 1024, 1, time.Hour)
+	if err != nil {
+		t.Fatalf("newRotateWriter: %v", err)
+	}
+	logger := &Logger{writer: rw}
+	defer logger.Close()
+	if err := logger.Info("test"); err != nil {
+		t.Fatalf("info: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("expected data written")
+	}
+}

--- a/internal/phases/first.go
+++ b/internal/phases/first.go
@@ -1,0 +1,56 @@
+package phases
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// FirstStep returns the first bullet point from the Detailed Steps section
+// of the specified phase file.
+func FirstStep(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open phase file: %w", err)
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	inSection := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "## ") && inSection {
+			break
+		}
+		if strings.EqualFold(strings.TrimSpace(line), "## Detailed Steps") {
+			inSection = true
+			continue
+		}
+		if inSection && strings.HasPrefix(strings.TrimSpace(line), "-") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "-")), nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("scan phase file: %w", err)
+	}
+	return "", fmt.Errorf("no bullet found in %s", path)
+}
+
+// PhaseFirstSteps reads all phase markdown files in the given directory
+// and returns a map of filename to first step bullet.
+func PhaseFirstSteps(dir string) (map[string]string, error) {
+	paths, err := filepath.Glob(filepath.Join(dir, "phase*.md"))
+	if err != nil {
+		return nil, fmt.Errorf("glob phases: %w", err)
+	}
+	steps := make(map[string]string)
+	for _, p := range paths {
+		step, err := FirstStep(p)
+		if err != nil {
+			return nil, err
+		}
+		steps[filepath.Base(p)] = step
+	}
+	return steps, nil
+}

--- a/internal/phases/first_test.go
+++ b/internal/phases/first_test.go
@@ -1,0 +1,32 @@
+package phases
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestFirstStep(t *testing.T) {
+	path := filepath.Join("..", "..", "docs", "phases", "phase01_core_app_foundation.md")
+	step, err := FirstStep(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := "Scaffold a new Wails v2 project using a Go backend and React frontend."
+	if step != expected {
+		t.Fatalf("got %q want %q", step, expected)
+	}
+}
+
+func TestPhaseFirstSteps(t *testing.T) {
+	dir := filepath.Join("..", "..", "docs", "phases")
+	steps, err := PhaseFirstSteps(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(steps) == 0 {
+		t.Fatal("expected steps")
+	}
+	if _, ok := steps["phase02_cli_session_manager.md"]; !ok {
+		t.Fatal("missing phase02 step")
+	}
+}


### PR DESCRIPTION
## Summary
- initialize Go module with Go 1.24 toolchain
- implement JSON logger with file rotation
- implement phase helper to read first step from each phase doc
- add `phasefirst` command to output first steps
- provide unit tests for logging and phase helpers
- document usage in new README

## Testing
- `go vet ./...`
- `go test -race ./...`


------
https://chatgpt.com/codex/tasks/task_e_686036a82478832a8e1f057bcf1227ea