### PR TITLE
Add Wails scaffold and CLI logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,15 @@ go vet ./...
 go test -race ./...
 ```
 
+## Wails Application
+
+The repository also contains a minimal Wails v2 application located in the
+`frontend` directory with a Go backend. Building requires Node.js 18 and the
+Wails CLI:
+
+```
+wails build -platform windows/amd64
+wails build -platform darwin/universal
+wails build -platform linux/amd64
+```
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ai-cli-ui",
+  "version": "0.0.1",
+  "scripts": {
+    "build": "echo build placeholder",
+    "start": "echo start placeholder"
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "5.2.2"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AI CLI UI</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import './App.css';
+
+function App() {
+  const [prompt, setPrompt] = useState('');
+  const [response, setResponse] = useState('');
+  const [tool, setTool] = useState('openai');
+
+  const send = async () => {
+    const res = await window.backend.RunPrompt(tool, prompt);
+    setResponse(res);
+  };
+
+  return (
+    <div>
+      <select value={tool} onChange={e => setTool(e.target.value)}>
+        <option value="openai">OpenAI</option>
+        <option value="gemini">Gemini</option>
+      </select>
+      <textarea value={prompt} onChange={e => setPrompt(e.target.value)} />
+      <button onClick={send}>Send</button>
+      <pre>{response}</pre>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -1,0 +1,40 @@
+package app
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+
+	"cli-wrapper/internal/logging"
+)
+
+// DetectCLITool returns the first available CLI tool.
+func DetectCLITool() (string, error) {
+	if _, err := exec.LookPath("openai"); err == nil {
+		return "openai", nil
+	}
+	if _, err := exec.LookPath("gemini"); err == nil {
+		return "gemini", nil
+	}
+	return "", fmt.Errorf("no supported CLI tool found")
+}
+
+// InvokeTool runs the given CLI with args and logs the invocation.
+func InvokeTool(tool string, args []string, baseDir string) error {
+	logPath := filepath.Join(baseDir, "logs", "logs.txt")
+	logger, err := logging.NewWithPath(logPath)
+	if err != nil {
+		return err
+	}
+	defer logger.Close()
+
+	cmd := exec.Command(tool, args...)
+	logger.Info(fmt.Sprintf("running %s %v", tool, args))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		logger.Error(fmt.Sprintf("%s failed: %v", tool, err))
+		return fmt.Errorf("run %s: %w", tool, err)
+	}
+	logger.Info(fmt.Sprintf("%s output: %s", tool, string(out)))
+	return nil
+}

--- a/internal/app/cli_test.go
+++ b/internal/app/cli_test.go
@@ -1,0 +1,9 @@
+package app
+
+import "testing"
+
+func TestDetectCLIToolNone(t *testing.T) {
+	if _, err := DetectCLITool(); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/app/paths.go
+++ b/internal/app/paths.go
@@ -1,0 +1,53 @@
+package app
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+func appDirForOS(goos string) (string, error) {
+	switch goos {
+	case "windows":
+		base := os.Getenv("APPDATA")
+		if base == "" {
+			return "", errors.New("APPDATA not set")
+		}
+		return filepath.Join(base, "ai-cli-ui"), nil
+	case "darwin":
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, "Library", "Application Support", "ai-cli-ui"), nil
+	default: // linux and others
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, ".config", "ai-cli-ui"), nil
+	}
+}
+
+// AppDir returns the base directory for application data depending on the OS.
+func AppDir() (string, error) {
+	return appDirForOS(runtime.GOOS)
+}
+
+// PrepareDirectories ensures the logs, config, and state directories exist and
+// returns the base path.
+func PrepareDirectories() (string, error) {
+	base, err := AppDir()
+	if err != nil {
+		return "", err
+	}
+	subdirs := []string{"logs", "config", "state"}
+	for _, d := range subdirs {
+		p := filepath.Join(base, d)
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			return "", err
+		}
+	}
+	return base, nil
+}

--- a/internal/app/paths_test.go
+++ b/internal/app/paths_test.go
@@ -1,0 +1,29 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAppDirForOS(t *testing.T) {
+	os.Setenv("APPDATA", `C:\\Data`)
+	path, err := appDirForOS("windows")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if filepath.Base(path) != "ai-cli-ui" {
+		t.Fatalf("unexpected base: %q", filepath.Base(path))
+	}
+
+	home := t.TempDir()
+	os.Setenv("HOME", home)
+	path, err = appDirForOS("darwin")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := filepath.Join(home, "Library", "Application Support", "ai-cli-ui")
+	if path != expected {
+		t.Fatalf("got %q want %q", path, expected)
+	}
+}

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -133,6 +133,15 @@ func New() (*Logger, error) {
 	return &Logger{writer: rw}, nil
 }
 
+// NewWithPath creates a logger that writes to the specified file path.
+func NewWithPath(path string) (*Logger, error) {
+	rw, err := newRotateWriter(path, 20*1024*1024, 5, 30*24*time.Hour)
+	if err != nil {
+		return nil, err
+	}
+	return &Logger{writer: rw}, nil
+}
+
 func (l *Logger) log(level, msg string) error {
 	entry := logEntry{
 		Timestamp: time.Now().UTC().Format(time.RFC3339),

--- a/wails.json
+++ b/wails.json
@@ -1,0 +1,21 @@
+{
+  "name": "ai-cli-ui",
+  "description": "Cross-platform wrapper for AI CLI tools",
+  "author": "cli-wrapper",
+  "frontend": {
+    "dir": "frontend",
+    "install": "npm install",
+    "build": "npm run build"
+  },
+  "platform": {
+    "windows": {
+      "arch": ["amd64"]
+    },
+    "darwin": {
+      "arch": ["universal"]
+    },
+    "linux": {
+      "arch": ["amd64"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold the initial Wails project files
- add cross-platform app directories
- detect supported CLI tools and log invocations
- update README with Wails build commands
- extend logging to allow a custom path

## Testing
- `go vet ./...`
- `go test -race ./...`


------
https://chatgpt.com/codex/tasks/task_e_6860396e23e4832aaa6eb8ca9959254b