### PR TITLE
Add session manager with concurrency limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,10 @@ wails build -platform darwin/universal
 wails build -platform linux/amd64
 ```
 
+## Session Manager
+
+The `internal/app` package now provides a `SessionManager` which limits concurrent
+CLI sessions. The limit is stored in `config.json` under the application's config
+directory. A default limit of one is used if no configuration exists. Sessions
+receive unique UUIDs and can be terminated programmatically.
+

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -1,0 +1,56 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Config holds persistent application settings.
+type Config struct {
+	Concurrency int `json:"concurrency"`
+}
+
+// LoadConfig reads configuration from the config directory.
+func LoadConfig(baseDir string) (Config, error) {
+	path := filepath.Join(baseDir, "config", "config.json")
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Config{Concurrency: 1}, nil
+		}
+		return Config{}, fmt.Errorf("open config: %w", err)
+	}
+	defer f.Close()
+	var cfg Config
+	if err := json.NewDecoder(f).Decode(&cfg); err != nil {
+		return Config{}, fmt.Errorf("decode config: %w", err)
+	}
+	if cfg.Concurrency < 1 || cfg.Concurrency > 5 {
+		cfg.Concurrency = 1
+	}
+	return cfg, nil
+}
+
+// SaveConfig writes configuration to the config directory.
+func SaveConfig(baseDir string, cfg Config) error {
+	if cfg.Concurrency < 1 || cfg.Concurrency > 5 {
+		return fmt.Errorf("invalid concurrency %d", cfg.Concurrency)
+	}
+	path := filepath.Join(baseDir, "config", "config.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("open config for write: %w", err)
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(cfg); err != nil {
+		return fmt.Errorf("encode config: %w", err)
+	}
+	return nil
+}

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -1,0 +1,31 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConfigLoadSave(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{Concurrency: 3}
+	if err := SaveConfig(dir, cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	loaded, err := LoadConfig(dir)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if loaded.Concurrency != 3 {
+		t.Fatalf("got %d want 3", loaded.Concurrency)
+	}
+	// corrupt file should default to 1
+	path := filepath.Join(dir, "config", "config.json")
+	if err := os.WriteFile(path, []byte("{"), 0o644); err != nil {
+		t.Fatalf("write corrupt: %v", err)
+	}
+	loaded, err = LoadConfig(dir)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/internal/app/session_manager.go
+++ b/internal/app/session_manager.go
@@ -1,0 +1,185 @@
+package app
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"sync"
+	"syscall"
+	"time"
+
+	"cli-wrapper/internal/logging"
+)
+
+// newUUID returns a random UUID string.
+func newUUID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("read random: %w", err)
+	}
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:]), nil
+}
+
+// Session represents a running CLI invocation.
+type Session struct {
+	ID     string
+	Cmd    *exec.Cmd
+	cancel context.CancelFunc
+	done   chan error
+}
+
+// SessionManager schedules CLI sessions with a concurrency limit.
+type SessionManager struct {
+	baseDir string
+	logger  *logging.Logger
+	queue   chan sessionRequest
+	active  map[string]*Session
+	mu      sync.Mutex
+	sem     chan struct{}
+	ctx     context.Context
+	cancel  context.CancelFunc
+}
+
+type sessionRequest struct {
+	id   string
+	tool string
+	args []string
+	res  chan error
+}
+
+// NewSessionManager creates a manager with the given concurrency limit.
+func NewSessionManager(baseDir string, logger *logging.Logger, concurrency int) *SessionManager {
+	ctx, cancel := context.WithCancel(context.Background())
+	m := &SessionManager{
+		baseDir: baseDir,
+		logger:  logger,
+		queue:   make(chan sessionRequest, 100),
+		active:  make(map[string]*Session),
+		sem:     make(chan struct{}, concurrency),
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+	go m.dispatch()
+	return m
+}
+
+func (m *SessionManager) dispatch() {
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case req := <-m.queue:
+			m.sem <- struct{}{}
+			go m.run(req)
+		}
+	}
+}
+
+// run executes a session and tracks it until completion.
+func (m *SessionManager) run(req sessionRequest) {
+	ctx, cancel := context.WithCancel(m.ctx)
+	cmd := exec.CommandContext(ctx, req.tool, req.args...)
+	sess := &Session{ID: req.id, Cmd: cmd, cancel: cancel, done: make(chan error, 1)}
+	m.mu.Lock()
+	m.active[req.id] = sess
+	m.mu.Unlock()
+
+	if err := cmd.Start(); err != nil {
+		m.logger.Error(fmt.Sprintf("start %s: %v", req.id, err))
+		req.res <- fmt.Errorf("start: %w", err)
+		m.remove(req.id)
+		<-m.sem
+		return
+	}
+	go func() {
+		err := cmd.Wait()
+		sess.done <- err
+		m.logger.Info(fmt.Sprintf("session %s finished", req.id))
+		m.remove(req.id)
+		<-m.sem
+	}()
+	req.res <- nil
+}
+
+func (m *SessionManager) remove(id string) {
+	m.mu.Lock()
+	delete(m.active, id)
+	m.mu.Unlock()
+}
+
+// AddSession queues a CLI invocation and returns its ID when scheduled.
+func (m *SessionManager) AddSession(tool string, args []string) (string, error) {
+	id, err := newUUID()
+	if err != nil {
+		return "", err
+	}
+	res := make(chan error, 1)
+	req := sessionRequest{id: id, tool: tool, args: args, res: res}
+	select {
+	case m.queue <- req:
+	case <-time.After(5 * time.Second):
+		return "", fmt.Errorf("queue timeout")
+	}
+	if err := <-res; err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+// Terminate stops a running session by ID.
+func (m *SessionManager) Terminate(id string) error {
+	m.mu.Lock()
+	sess, ok := m.active[id]
+	m.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("unknown session %s", id)
+	}
+	if err := terminateProcess(sess.Cmd); err != nil {
+		if !errors.Is(err, os.ErrProcessDone) {
+			return err
+		}
+	}
+	sess.cancel()
+	<-sess.done
+	return nil
+}
+
+func terminateProcess(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return fmt.Errorf("process not started")
+	}
+	if runtime.GOOS == "windows" {
+		return cmd.Process.Kill()
+	}
+	_ = cmd.Process.Signal(syscall.SIGTERM)
+	time.Sleep(100 * time.Millisecond)
+	return cmd.Process.Kill()
+}
+
+// Sessions returns the IDs of running sessions.
+func (m *SessionManager) Sessions() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ids := make([]string, 0, len(m.active))
+	for id := range m.active {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// Close stops all workers and running sessions.
+func (m *SessionManager) Close() {
+	m.cancel()
+	m.mu.Lock()
+	for _, s := range m.active {
+		terminateProcess(s.Cmd)
+		s.cancel()
+		<-s.done
+	}
+	m.active = make(map[string]*Session)
+	m.mu.Unlock()
+}

--- a/internal/app/session_manager_test.go
+++ b/internal/app/session_manager_test.go
@@ -1,0 +1,51 @@
+package app
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"cli-wrapper/internal/logging"
+)
+
+func TestSessionManagerQueue(t *testing.T) {
+	logger, _ := logging.NewWithPath(filepath.Join(t.TempDir(), "log.txt"))
+	defer logger.Close()
+	m := NewSessionManager(t.TempDir(), logger, 1)
+	defer m.Close()
+
+	start := time.Now()
+	id1, err := m.AddSession("sh", []string{"-c", "sleep 0.1"})
+	if err != nil {
+		t.Fatalf("add1: %v", err)
+	}
+	id2, err := m.AddSession("sh", []string{"-c", "sleep 0.1"})
+	if err != nil {
+		t.Fatalf("add2: %v", err)
+	}
+	if id1 == id2 {
+		t.Fatalf("duplicate ids")
+	}
+	for len(m.Sessions()) > 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if time.Since(start) < 190*time.Millisecond {
+		t.Fatalf("sessions did not run sequentially")
+	}
+}
+
+func TestSessionTerminate(t *testing.T) {
+	logger, _ := logging.NewWithPath(filepath.Join(t.TempDir(), "log.txt"))
+	defer logger.Close()
+	m := NewSessionManager(t.TempDir(), logger, 1)
+	defer m.Close()
+
+	id, err := m.AddSession("sh", []string{"-c", "sleep 2"})
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if err := m.Terminate(id); err != nil {
+		t.Fatalf("terminate: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add `SessionManager` package for queued CLI sessions
- persist concurrency config in `config.json`
- document session manager usage in README

## Testing
- `go vet ./...`
- `go test -race ./...`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68603e79f79c832ab9b241099c1123f3