### PR TITLE
Configure Vite and Tailwind build

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,5 +7,6 @@
 </head>
 <body>
   <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
 </body>
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,14 +2,19 @@
   "name": "ai-cli-ui",
   "version": "0.0.1",
   "scripts": {
-    "build": "echo build placeholder",
-    "start": "echo start placeholder"
+    "build": "vite build",
+    "start": "vite dev"
   },
   "dependencies": {
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "typescript": "5.2.2"
+    "typescript": "5.2.2",
+    "vite": "^5.2.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0"
   }
 }

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx,js,jsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- add Vite build pipeline and Tailwind CSS support
- supply PostCSS and Tailwind config files
- add base stylesheet and HTML entry for Vite
- remove placeholder build scripts

## Testing
- `go vet ./...`
- `go test -race ./...`
- `npm test --prefix frontend` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6860608c3d3c832aaecff0050f4b8583