### PR TITLE
Add configurable theme with toggle

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -27,7 +27,7 @@ func main() {
 	mgr := app.NewSessionManager(base, logger, cfg.Concurrency)
 	defer mgr.Close()
 
-	srv := server.New(mgr, logger)
+	srv := server.New(mgr, logger, base, &cfg)
 	if err := srv.Start(":8080"); err != nil {
 		log.Fatal(err)
 	}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import "./App.css";
 import SessionList from "./components/SessionList";
 import ModelSelector from "./components/ModelSelector";
 import ResourceMeter from "./components/ResourceMeter";
+import ThemeToggle from "./components/ThemeToggle";
 
 function App() {
   const [prompt, setPrompt] = useState("");
@@ -22,7 +23,10 @@ function App() {
       <main className="flex-1 p-4 flex flex-col space-y-4">
         <div className="flex justify-between items-center">
           <ModelSelector selected={model} onChange={setModel} />
-          <ResourceMeter />
+          <div className="flex items-center space-x-2">
+            <ResourceMeter />
+            <ThemeToggle />
+          </div>
         </div>
         <textarea
           className="border rounded p-2 flex-1"

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch("http://localhost:8080/theme");
+        if (res.ok) {
+          const data = await res.json();
+          if (data.theme === "light" || data.theme === "dark") {
+            setTheme(data.theme);
+          }
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", theme === "dark");
+  }, [theme]);
+
+  const toggle = async () => {
+    const next = theme === "light" ? "dark" : "light";
+    setTheme(next);
+    try {
+      await fetch("http://localhost:8080/theme", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ theme: next }),
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <button className="border rounded px-2 py-1" onClick={toggle} aria-label="Toggle theme">
+      {theme === "light" ? "Dark Mode" : "Light Mode"}
+    </button>
+  );
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{ts,tsx,js,jsx}'],
   theme: {
     extend: {},

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -8,9 +8,18 @@ import (
 )
 
 // Config holds persistent application settings.
+// Config struct includes both runtime and UI preferences.
 type Config struct {
-	Concurrency int `json:"concurrency"`
+	Concurrency int    `json:"concurrency"`
+	Theme       string `json:"theme"`
 }
+
+// ValidTheme reports whether the provided theme value is supported.
+func ValidTheme(t string) bool {
+	return t == "light" || t == "dark"
+}
+
+const defaultTheme = "light"
 
 // LoadConfig reads configuration from the config directory.
 func LoadConfig(baseDir string) (Config, error) {
@@ -18,7 +27,7 @@ func LoadConfig(baseDir string) (Config, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return Config{Concurrency: 1}, nil
+			return Config{Concurrency: 1, Theme: defaultTheme}, nil
 		}
 		return Config{}, fmt.Errorf("open config: %w", err)
 	}
@@ -30,6 +39,9 @@ func LoadConfig(baseDir string) (Config, error) {
 	if cfg.Concurrency < 1 || cfg.Concurrency > 5 {
 		cfg.Concurrency = 1
 	}
+	if !ValidTheme(cfg.Theme) {
+		cfg.Theme = defaultTheme
+	}
 	return cfg, nil
 }
 
@@ -37,6 +49,9 @@ func LoadConfig(baseDir string) (Config, error) {
 func SaveConfig(baseDir string, cfg Config) error {
 	if cfg.Concurrency < 1 || cfg.Concurrency > 5 {
 		return fmt.Errorf("invalid concurrency %d", cfg.Concurrency)
+	}
+	if !ValidTheme(cfg.Theme) {
+		return fmt.Errorf("invalid theme %q", cfg.Theme)
 	}
 	path := filepath.Join(baseDir, "config", "config.json")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestConfigLoadSave(t *testing.T) {
 	dir := t.TempDir()
-	cfg := Config{Concurrency: 3}
+	cfg := Config{Concurrency: 3, Theme: "dark"}
 	if err := SaveConfig(dir, cfg); err != nil {
 		t.Fatalf("save config: %v", err)
 	}
@@ -19,6 +19,9 @@ func TestConfigLoadSave(t *testing.T) {
 	if loaded.Concurrency != 3 {
 		t.Fatalf("got %d want 3", loaded.Concurrency)
 	}
+	if loaded.Theme != "dark" {
+		t.Fatalf("got %s want dark", loaded.Theme)
+	}
 	// corrupt file should default to 1
 	path := filepath.Join(dir, "config", "config.json")
 	if err := os.WriteFile(path, []byte("{"), 0o644); err != nil {
@@ -27,5 +30,10 @@ func TestConfigLoadSave(t *testing.T) {
 	loaded, err = LoadConfig(dir)
 	if err == nil {
 		t.Fatalf("expected error")
+	}
+
+	cfg.Theme = "invalid"
+	if err := SaveConfig(dir, cfg); err == nil {
+		t.Fatal("expected error for invalid theme")
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,14 +11,16 @@ import (
 
 // Server exposes HTTP endpoints for the frontend.
 type Server struct {
-	mgr    *app.SessionManager
-	logger *logging.Logger
-	mux    *http.ServeMux
+	mgr     *app.SessionManager
+	logger  *logging.Logger
+	baseDir string
+	cfg     *app.Config
+	mux     *http.ServeMux
 }
 
 // New creates a Server with its routes configured.
-func New(mgr *app.SessionManager, logger *logging.Logger) *Server {
-	s := &Server{mgr: mgr, logger: logger, mux: http.NewServeMux()}
+func New(mgr *app.SessionManager, logger *logging.Logger, baseDir string, cfg *app.Config) *Server {
+	s := &Server{mgr: mgr, logger: logger, baseDir: baseDir, cfg: cfg, mux: http.NewServeMux()}
 	s.routes()
 	return s
 }
@@ -27,6 +29,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("/sessions", s.handleSessions)
 	s.mux.HandleFunc("/resource", s.handleResource)
 	s.mux.HandleFunc("/models", s.handleModels)
+	s.mux.HandleFunc("/theme", s.handleTheme)
 }
 
 func (s *Server) respondJSON(w http.ResponseWriter, v any) {
@@ -56,6 +59,34 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.respondJSON(w, tools)
+}
+
+func (s *Server) handleTheme(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.respondJSON(w, map[string]string{"theme": s.cfg.Theme})
+	case http.MethodPost:
+		var req struct {
+			Theme string `json:"theme"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if !app.ValidTheme(req.Theme) {
+			http.Error(w, "invalid theme", http.StatusBadRequest)
+			return
+		}
+		s.cfg.Theme = req.Theme
+		if err := app.SaveConfig(s.baseDir, *s.cfg); err != nil {
+			s.logger.Error("save theme: " + err.Error())
+			http.Error(w, "internal", http.StatusInternalServerError)
+			return
+		}
+		s.respondJSON(w, map[string]string{"theme": s.cfg.Theme})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
 }
 
 // Start listens on the given address.


### PR DESCRIPTION
## Summary
- store theme preference in config
- expose `/theme` endpoint to read and update preference
- display toggle in UI and apply theme via `dark` class

## Testing
- `npm test --prefix frontend` *(fails: Missing script)*
- `go vet ./...`
- `go test -race ./...`

------
https://chatgpt.com/codex/tasks/task_e_686063a6916c832aa2130216fe109cac