### PR TITLE
Add model switch tracking and Wails alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,9 @@ CLI sessions. The limit is stored in `config.json` under the application's confi
 directory. A default limit of one is used if no configuration exists. Sessions
 receive unique UUIDs and can be terminated programmatically.
 
+## Model Switch Alerts
+
+The Wails backend tracks the last-used model. When a new prompt specifies a different
+model, the backend emits a `model:switched` event via the Wails event bus and logs the
+change in JSON Lines format. Log files automatically rotate after reaching 20 MB.
+

--- a/cmd/wailsapp/main.go
+++ b/cmd/wailsapp/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"log"
+	"path/filepath"
+
+	"github.com/wailsapp/wails/v2"
+
+	"cli-wrapper/internal/app"
+	"cli-wrapper/internal/logging"
+)
+
+func main() {
+	base, err := app.PrepareDirectories()
+	if err != nil {
+		log.Fatal(err)
+	}
+	cfg, err := app.LoadConfig(base)
+	if err != nil {
+		log.Fatal(err)
+	}
+	logger, err := logging.NewWithPath(filepath.Join(base, "logs", "logs.txt"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer logger.Close()
+	mgr := app.NewSessionManager(base, logger, cfg.Concurrency)
+	defer mgr.Close()
+	backend := app.NewBackend(mgr, logger, &cfg)
+	err = wails.Run(&wails.Options{Bind: []interface{}{backend}, OnStartup: backend.Startup})
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
   },
   "dependencies": {
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "@wailsio/runtime": "^2.6.0"
   },
   "devDependencies": {
     "typescript": "5.2.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,13 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { EventsOn } from "@wailsio/runtime";
+
+declare global {
+  interface Window {
+    backend: {
+      RunPrompt(model: string, prompt: string): Promise<string>;
+    };
+  }
+}
 import "./App.css";
 import SessionList from "./components/SessionList";
 import ModelSelector from "./components/ModelSelector";
@@ -9,6 +18,19 @@ function App() {
   const [prompt, setPrompt] = useState("");
   const [response, setResponse] = useState("");
   const [model, setModel] = useState("");
+  const [alert, setAlert] = useState("");
+
+  useEffect(() => {
+    const unsub = EventsOn("model:switched", (data: any) => {
+      if (data && data.from && data.to) {
+        setAlert(`\u26A0\uFE0F Model switched from ${data.from} to ${data.to}`);
+        setTimeout(() => setAlert(""), 4000);
+      }
+    });
+    return () => {
+      unsub();
+    };
+  }, []);
 
   const send = async () => {
     const res = await window.backend.RunPrompt(model, prompt);
@@ -28,6 +50,11 @@ function App() {
             <ThemeToggle />
           </div>
         </div>
+        {alert && (
+          <div className="text-yellow-600" role="alert">
+            {alert}
+          </div>
+        )}
         <textarea
           className="border rounded p-2 flex-1"
           value={prompt}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module cli-wrapper
 go 1.24
 
 require github.com/shirou/gopsutil/v3 v3.23.3
+require github.com/wailsapp/wails/v2 v2.6.0
 
 require (
 	github.com/go-ole/go-ole v1.2.6 // indirect

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -12,6 +12,7 @@ import (
 type Config struct {
 	Concurrency int    `json:"concurrency"`
 	Theme       string `json:"theme"`
+	ModelAlerts bool   `json:"modelAlerts"`
 }
 
 // ValidTheme reports whether the provided theme value is supported.
@@ -27,7 +28,7 @@ func LoadConfig(baseDir string) (Config, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return Config{Concurrency: 1, Theme: defaultTheme}, nil
+			return Config{Concurrency: 1, Theme: defaultTheme, ModelAlerts: true}, nil
 		}
 		return Config{}, fmt.Errorf("open config: %w", err)
 	}
@@ -42,6 +43,10 @@ func LoadConfig(baseDir string) (Config, error) {
 	if !ValidTheme(cfg.Theme) {
 		cfg.Theme = defaultTheme
 	}
+	if !cfg.ModelAlerts {
+		// missing field defaults to true when false and file existed
+		cfg.ModelAlerts = true
+	}
 	return cfg, nil
 }
 
@@ -52,6 +57,9 @@ func SaveConfig(baseDir string, cfg Config) error {
 	}
 	if !ValidTheme(cfg.Theme) {
 		return fmt.Errorf("invalid theme %q", cfg.Theme)
+	}
+	if !cfg.ModelAlerts {
+		// allow both true and false; no validation necessary
 	}
 	path := filepath.Join(baseDir, "config", "config.json")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/app/wails_backend.go
+++ b/internal/app/wails_backend.go
@@ -1,0 +1,47 @@
+package app
+
+import (
+	"context"
+	"fmt"
+
+	"cli-wrapper/internal/logging"
+	"github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+// Backend exposes methods to the Wails frontend.
+type Backend struct {
+	ctx       context.Context
+	mgr       *SessionManager
+	logger    *logging.Logger
+	cfg       *Config
+	lastModel string
+}
+
+// NewBackend creates a Backend instance.
+func NewBackend(mgr *SessionManager, logger *logging.Logger, cfg *Config) *Backend {
+	return &Backend{mgr: mgr, logger: logger, cfg: cfg}
+}
+
+// Startup stores the context for runtime events.
+func (b *Backend) Startup(ctx context.Context) {
+	b.ctx = ctx
+}
+
+// RunPrompt executes the given model with the prompt.
+func (b *Backend) RunPrompt(model, prompt string) (string, error) {
+	if model == "" {
+		return "", fmt.Errorf("model required")
+	}
+	if b.lastModel != "" && model != b.lastModel {
+		if b.cfg.ModelAlerts {
+			runtime.EventsEmit(b.ctx, "model:switched", map[string]string{"from": b.lastModel, "to": model})
+		}
+		_ = b.logger.ModelSwitch(b.lastModel, model, prompt)
+	}
+	b.lastModel = model
+	id, err := b.mgr.AddSession(model, []string{prompt})
+	if err != nil {
+		return "", err
+	}
+	return id, nil
+}

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -158,6 +158,35 @@ func (l *Logger) log(level, msg string) error {
 	return nil
 }
 
+type modelSwitchEntry struct {
+	Timestamp string `json:"timestamp"`
+	Level     string `json:"level"`
+	Event     string `json:"event"`
+	From      string `json:"from"`
+	To        string `json:"to"`
+	Prompt    string `json:"prompt"`
+}
+
+// ModelSwitch logs a model change event with prompt text.
+func (l *Logger) ModelSwitch(from, to, prompt string) error {
+	entry := modelSwitchEntry{
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Level:     "INFO",
+		Event:     "model_switch",
+		From:      from,
+		To:        to,
+		Prompt:    prompt,
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("marshal log: %w", err)
+	}
+	if _, err := l.writer.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("write log: %w", err)
+	}
+	return nil
+}
+
 func (l *Logger) Info(msg string) error {
 	return l.log("INFO", msg)
 }


### PR DESCRIPTION
## Summary
- track last used model in config
- log model switch events in JSON format
- emit `model:switched` via Wails event bus
- add Wails backend and application entry
- display model switch alert in the React UI

## Testing
- `go mod tidy` *(fails: forbidden access to storage.googleapis.com)*
- `go vet ./...` *(fails: missing go.sum entry for wails)*
- `go test -race ./...` *(fails: missing go.sum entry for wails)*
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686098e51dec832ab7ac8eb8eb5cdcee