### PR TITLE
Add session resource monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ CLI sessions. The limit is stored in `config.json` under the application's confi
 directory. A default limit of one is used if no configuration exists. Sessions
 receive unique UUIDs and can be terminated programmatically.
 
+Resource throttling parameters are also configurable via `config.json`:
+
+```
+{
+  "cpuThreshold": 35,
+  "memoryThreshold": 35,
+  "pollInterval": 2
+}
+```
+If a running session exceeds these CPU or memory limits it is first throttled by
+reducing process priority. Persistent overages cause the session to be
+terminated. All alerts are recorded in `logs.txt`.
+
 ## Model Switch Alerts
 
 The Wails backend tracks the last-used model. When a new prompt specifies a different

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -24,7 +24,7 @@ func main() {
 	}
 	defer logger.Close()
 
-	mgr := app.NewSessionManager(base, logger, cfg.Concurrency)
+	mgr := app.NewSessionManager(base, logger, cfg.Concurrency, &cfg)
 	defer mgr.Close()
 
 	srv := server.New(mgr, logger, base, &cfg)

--- a/cmd/wailsapp/main.go
+++ b/cmd/wailsapp/main.go
@@ -24,7 +24,7 @@ func main() {
 		log.Fatal(err)
 	}
 	defer logger.Close()
-	mgr := app.NewSessionManager(base, logger, cfg.Concurrency)
+	mgr := app.NewSessionManager(base, logger, cfg.Concurrency, &cfg)
 	defer mgr.Close()
 	backend := app.NewBackend(mgr, logger, &cfg)
 	err = wails.Run(&wails.Options{Bind: []interface{}{backend}, OnStartup: backend.Startup})

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestConfigLoadSave(t *testing.T) {
 	dir := t.TempDir()
-	cfg := Config{Concurrency: 3, Theme: "dark"}
+	cfg := Config{Concurrency: 3, Theme: "dark", CPUThreshold: 50, MemoryThreshold: 50, PollInterval: 2}
 	if err := SaveConfig(dir, cfg); err != nil {
 		t.Fatalf("save config: %v", err)
 	}
@@ -21,6 +21,9 @@ func TestConfigLoadSave(t *testing.T) {
 	}
 	if loaded.Theme != "dark" {
 		t.Fatalf("got %s want dark", loaded.Theme)
+	}
+	if loaded.CPUThreshold != 50 || loaded.MemoryThreshold != 50 {
+		t.Fatalf("thresholds not saved")
 	}
 	// corrupt file should default to 1
 	path := filepath.Join(dir, "config", "config.json")
@@ -35,5 +38,21 @@ func TestConfigLoadSave(t *testing.T) {
 	cfg.Theme = "invalid"
 	if err := SaveConfig(dir, cfg); err == nil {
 		t.Fatal("expected error for invalid theme")
+	}
+
+	cfg.Theme = "dark"
+	cfg.CPUThreshold = -1
+	if err := SaveConfig(dir, cfg); err == nil {
+		t.Fatal("expected error for invalid CPU threshold")
+	}
+	cfg.CPUThreshold = 50
+	cfg.MemoryThreshold = 0
+	if err := SaveConfig(dir, cfg); err == nil {
+		t.Fatal("expected error for invalid memory threshold")
+	}
+	cfg.MemoryThreshold = 50
+	cfg.PollInterval = 0
+	if err := SaveConfig(dir, cfg); err == nil {
+		t.Fatal("expected error for invalid poll interval")
 	}
 }

--- a/internal/app/session_manager_test.go
+++ b/internal/app/session_manager_test.go
@@ -11,7 +11,8 @@ import (
 func TestSessionManagerQueue(t *testing.T) {
 	logger, _ := logging.NewWithPath(filepath.Join(t.TempDir(), "log.txt"))
 	defer logger.Close()
-	m := NewSessionManager(t.TempDir(), logger, 1)
+	cfg := &Config{Concurrency: 1, CPUThreshold: 50, MemoryThreshold: 50, PollInterval: 1}
+	m := NewSessionManager(t.TempDir(), logger, 1, cfg)
 	defer m.Close()
 
 	start := time.Now()
@@ -37,7 +38,8 @@ func TestSessionManagerQueue(t *testing.T) {
 func TestSessionTerminate(t *testing.T) {
 	logger, _ := logging.NewWithPath(filepath.Join(t.TempDir(), "log.txt"))
 	defer logger.Close()
-	m := NewSessionManager(t.TempDir(), logger, 1)
+	cfg := &Config{Concurrency: 1, CPUThreshold: 50, MemoryThreshold: 50, PollInterval: 1}
+	m := NewSessionManager(t.TempDir(), logger, 1, cfg)
 	defer m.Close()
 
 	id, err := m.AddSession("sh", []string{"-c", "sleep 2"})

--- a/internal/app/throttle_unix.go
+++ b/internal/app/throttle_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package app
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+)
+
+func throttleProcess(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return fmt.Errorf("process not started")
+	}
+	return syscall.Setpriority(syscall.PRIO_PROCESS, cmd.Process.Pid, 10)
+}

--- a/internal/app/throttle_windows.go
+++ b/internal/app/throttle_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package app
+
+import (
+	"fmt"
+	"golang.org/x/sys/windows"
+	"os/exec"
+)
+
+func throttleProcess(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return fmt.Errorf("process not started")
+	}
+	return windows.SetPriorityClass(windows.Handle(cmd.Process.Pid), windows.BELOW_NORMAL_PRIORITY_CLASS)
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -15,8 +15,8 @@ import (
 func TestEndpoints(t *testing.T) {
 	dir := t.TempDir()
 	logger, _ := logging.NewWithPath(filepath.Join(dir, "log.txt"))
-	cfg := &app.Config{Concurrency: 1, Theme: "light"}
-	mgr := app.NewSessionManager(dir, logger, 1)
+	cfg := &app.Config{Concurrency: 1, Theme: "light", CPUThreshold: 50, MemoryThreshold: 50, PollInterval: 2}
+	mgr := app.NewSessionManager(dir, logger, 1, cfg)
 	defer mgr.Close()
 
 	srv := New(mgr, logger, dir, cfg)

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/mem"
+	"github.com/shirou/gopsutil/v3/process"
 )
 
 // Usage represents CPU and memory usage percentages.
@@ -28,4 +29,21 @@ func Read() (Usage, error) {
 		cpuVal = cpuPercents[0]
 	}
 	return Usage{CPU: cpuVal, Memory: vm.UsedPercent}, nil
+}
+
+// ReadProcess returns CPU and memory usage for the given process ID.
+func ReadProcess(pid int32) (Usage, error) {
+	p, err := process.NewProcess(pid)
+	if err != nil {
+		return Usage{}, fmt.Errorf("new process: %w", err)
+	}
+	cpuPercent, err := p.CPUPercent()
+	if err != nil {
+		return Usage{}, fmt.Errorf("cpu percent: %w", err)
+	}
+	memPercent, err := p.MemoryPercent()
+	if err != nil {
+		return Usage{}, fmt.Errorf("memory percent: %w", err)
+	}
+	return Usage{CPU: cpuPercent, Memory: float64(memPercent)}, nil
 }

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -1,16 +1,32 @@
 package telemetry
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
 func TestRead(t *testing.T) {
-    u, err := Read()
-    if err != nil {
-        t.Fatalf("read: %v", err)
-    }
-    if u.CPU < 0 || u.CPU > 100 {
-        t.Fatalf("cpu out of range: %v", u.CPU)
-    }
-    if u.Memory < 0 || u.Memory > 100 {
-        t.Fatalf("mem out of range: %v", u.Memory)
-    }
+	u, err := Read()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if u.CPU < 0 || u.CPU > 100 {
+		t.Fatalf("cpu out of range: %v", u.CPU)
+	}
+	if u.Memory < 0 || u.Memory > 100 {
+		t.Fatalf("mem out of range: %v", u.Memory)
+	}
+}
+
+func TestReadProcess(t *testing.T) {
+	u, err := ReadProcess(int32(os.Getpid()))
+	if err != nil {
+		t.Fatalf("read process: %v", err)
+	}
+	if u.CPU < 0 || u.CPU > 100 {
+		t.Fatalf("cpu out of range: %v", u.CPU)
+	}
+	if u.Memory < 0 || u.Memory > 100 {
+		t.Fatalf("mem out of range: %v", u.Memory)
+	}
 }


### PR DESCRIPTION
## Summary
- support CPU and memory limits in config
- monitor processes with gopsutil and throttle/terminate
- add platform-specific throttle helpers
- document resource thresholds

## Testing
- `go vet ./...` *(fails: missing go.sum entry for wailsapp packages)*
- `go test -race ./...` *(fails: missing go.sum entry for wailsapp packages)*

------
https://chatgpt.com/codex/tasks/task_e_686116c3bd1c832aa120850096ed344d