### PR TITLE
Add SQLite history and UI viewer

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"log"
-	"path/filepath"
+        "log"
+        "path/filepath"
 
-	"cli-wrapper/internal/app"
-	"cli-wrapper/internal/logging"
-	"cli-wrapper/internal/server"
+        "cli-wrapper/internal/app"
+        "cli-wrapper/internal/history"
+        "cli-wrapper/internal/logging"
+        "cli-wrapper/internal/server"
 )
 
 func main() {
@@ -18,16 +19,22 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	logger, err := logging.NewWithPath(filepath.Join(base, "logs", "logs.txt"))
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer logger.Close()
+        logger, err := logging.NewWithPath(filepath.Join(base, "logs", "logs.txt"))
+        if err != nil {
+                log.Fatal(err)
+        }
+        defer logger.Close()
 
-	mgr := app.NewSessionManager(base, logger, cfg.Concurrency, &cfg)
-	defer mgr.Close()
+        hist, err := history.New(base)
+        if err != nil {
+                log.Fatal(err)
+        }
+        defer hist.Close()
 
-	srv := server.New(mgr, logger, base, &cfg)
+        mgr := app.NewSessionManager(base, logger, cfg.Concurrency, &cfg, hist)
+        defer mgr.Close()
+
+        srv := server.New(mgr, logger, base, &cfg, hist)
 	if err := srv.Start(":8080"); err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/wailsapp/main.go
+++ b/cmd/wailsapp/main.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"log"
-	"path/filepath"
+        "log"
+        "path/filepath"
 
-	"github.com/wailsapp/wails/v2"
+        "github.com/wailsapp/wails/v2"
 
-	"cli-wrapper/internal/app"
-	"cli-wrapper/internal/logging"
+        "cli-wrapper/internal/app"
+        "cli-wrapper/internal/history"
+        "cli-wrapper/internal/logging"
 )
 
 func main() {
@@ -19,14 +20,20 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	logger, err := logging.NewWithPath(filepath.Join(base, "logs", "logs.txt"))
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer logger.Close()
-	mgr := app.NewSessionManager(base, logger, cfg.Concurrency, &cfg)
-	defer mgr.Close()
-	backend := app.NewBackend(mgr, logger, &cfg)
+        logger, err := logging.NewWithPath(filepath.Join(base, "logs", "logs.txt"))
+        if err != nil {
+                log.Fatal(err)
+        }
+        defer logger.Close()
+        hist, err := history.New(base)
+        if err != nil {
+                log.Fatal(err)
+        }
+        defer hist.Close()
+
+        mgr := app.NewSessionManager(base, logger, cfg.Concurrency, &cfg, hist)
+        defer mgr.Close()
+        backend := app.NewBackend(mgr, logger, &cfg)
 	err = wails.Run(&wails.Options{Bind: []interface{}{backend}, OnStartup: backend.Startup})
 	if err != nil {
 		log.Fatal(err)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import SessionList from "./components/SessionList";
 import ModelSelector from "./components/ModelSelector";
 import ResourceMeter from "./components/ResourceMeter";
 import ThemeToggle from "./components/ThemeToggle";
+import HistoryViewer from "./components/HistoryViewer";
 
 function App() {
   const [prompt, setPrompt] = useState("");
@@ -41,6 +42,7 @@ function App() {
     <div className="flex h-screen">
       <aside className="w-48 bg-gray-100 dark:bg-gray-800 overflow-y-auto">
         <SessionList />
+        <HistoryViewer />
       </aside>
       <main className="flex-1 p-4 flex flex-col space-y-4">
         <div className="flex justify-between items-center">

--- a/frontend/src/components/HistoryViewer.tsx
+++ b/frontend/src/components/HistoryViewer.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState, ChangeEvent } from "react";
+
+interface Record {
+  id: string;
+  prompt: string;
+  response: string;
+  model: string;
+  timestamp: string;
+  success: boolean;
+}
+
+export default function HistoryViewer() {
+  const [query, setQuery] = useState("");
+  const [records, setRecords] = useState<Record[]>([]);
+
+  const search = async () => {
+    const res = await fetch(`/history/search?q=${encodeURIComponent(query)}`);
+    if (res.ok) {
+      setRecords(await res.json());
+    }
+  };
+
+  const exportHist = async () => {
+    const res = await fetch("/history/export");
+    if (res.ok) {
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "history.json";
+      a.click();
+      URL.revokeObjectURL(url);
+    }
+  };
+
+  const importHist = async (e: ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files?.length) return;
+    const text = await e.target.files[0].text();
+    await fetch("/history", { method: "POST", headers: { "Content-Type": "application/json" }, body: text });
+    e.target.value = "";
+    search();
+  };
+
+  useEffect(() => {
+    search();
+  }, []);
+
+  return (
+    <div className="p-2 border-t mt-2">
+      <h2 className="text-lg font-semibold mb-2">History</h2>
+      <div className="flex mb-2">
+        <input className="border p-1 flex-1" value={query} onChange={(e) => setQuery(e.target.value)} />
+        <button className="bg-blue-500 text-white px-2 ml-2" onClick={search}>Search</button>
+      </div>
+      <div className="flex items-center space-x-2 mb-2">
+        <button className="bg-green-500 text-white px-2" onClick={exportHist}>Export</button>
+        <label className="bg-gray-200 p-1 cursor-pointer">
+          Import<input type="file" className="hidden" onChange={importHist} />
+        </label>
+      </div>
+      <ul className="space-y-1 overflow-y-auto" style={{ maxHeight: "200px" }}>
+        {records.map((r) => (
+          <li key={r.id} className="text-sm">
+            <div className="font-mono">{r.prompt}</div>
+            <div className="text-gray-500 truncate">{r.response}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24
 
 require github.com/shirou/gopsutil/v3 v3.23.3
 require github.com/wailsapp/wails/v2 v2.6.0
+require modernc.org/sqlite v1.38.0
 
 require (
 	github.com/go-ole/go-ole v1.2.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,3 +41,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+github.com/wailsapp/wails/v2 v2.6.0 h1:EyH0zR/EO6dDiqNy8qU5spaXDfkluiq77xrkabPYD4c=
+github.com/wailsapp/wails/v2 v2.6.0/go.mod h1:WBG9KKWuw0FKfoepBrr/vRlyTmHaMibWesK3yz6nNiM=
+modernc.org/sqlite v1.38.0 h1:+4OrfPQ8pxHKuWG4md1JpR/EYAh3Md7TdejuuzE7EUI=
+modernc.org/sqlite v1.38.0/go.mod h1:1Bj+yES4SVvBZ4cBOpVZ6QgesMCKpJZDq0nxYzOpmNE=

--- a/internal/app/session_manager.go
+++ b/internal/app/session_manager.go
@@ -1,20 +1,22 @@
 package app
 
 import (
-	"context"
-	"crypto/rand"
-	"errors"
-	"fmt"
-	"os"
-	"os/exec"
-	"runtime"
-	"sync"
-	"syscall"
-	"time"
+        "bytes"
+        "context"
+        "crypto/rand"
+        "errors"
+        "fmt"
+        "os"
+        "os/exec"
+        "runtime"
+        "sync"
+        "syscall"
+        "time"
 
-	"cli-wrapper/internal/logging"
-	"cli-wrapper/internal/telemetry"
-	"github.com/shirou/gopsutil/v3/process"
+        "cli-wrapper/internal/history"
+        "cli-wrapper/internal/logging"
+        "cli-wrapper/internal/telemetry"
+        "github.com/shirou/gopsutil/v3/process"
 )
 
 // newUUID returns a random UUID string.
@@ -28,48 +30,52 @@ func newUUID() (string, error) {
 
 // Session represents a running CLI invocation.
 type Session struct {
-	ID        string
-	Model     string
-	Cmd       *exec.Cmd
-	cancel    context.CancelFunc
-	done      chan error
-	proc      *process.Process
-	throttled bool
+        ID        string
+        Model     string
+        Prompt    string
+        Cmd       *exec.Cmd
+        cancel    context.CancelFunc
+        done      chan error
+        proc      *process.Process
+        throttled bool
 }
 
 // SessionManager schedules CLI sessions with a concurrency limit.
 type SessionManager struct {
-	baseDir string
-	logger  *logging.Logger
-	queue   chan sessionRequest
-	active  map[string]*Session
-	mu      sync.Mutex
-	sem     chan struct{}
-	ctx     context.Context
-	cancel  context.CancelFunc
-	cfg     *Config
+        baseDir string
+        logger  *logging.Logger
+        queue   chan sessionRequest
+        active  map[string]*Session
+        mu      sync.Mutex
+        sem     chan struct{}
+        ctx     context.Context
+        cancel  context.CancelFunc
+        cfg     *Config
+        hist    *history.Store
 }
 
 type sessionRequest struct {
-	id    string
-	model string
-	args  []string
-	res   chan error
+        id    string
+        model string
+        prompt string
+        args  []string
+        res   chan error
 }
 
 // NewSessionManager creates a manager with the given concurrency limit.
-func NewSessionManager(baseDir string, logger *logging.Logger, concurrency int, cfg *Config) *SessionManager {
-	ctx, cancel := context.WithCancel(context.Background())
-	m := &SessionManager{
-		baseDir: baseDir,
-		logger:  logger,
-		queue:   make(chan sessionRequest, 100),
-		active:  make(map[string]*Session),
-		sem:     make(chan struct{}, concurrency),
-		ctx:     ctx,
-		cancel:  cancel,
-		cfg:     cfg,
-	}
+func NewSessionManager(baseDir string, logger *logging.Logger, concurrency int, cfg *Config, hist *history.Store) *SessionManager {
+        ctx, cancel := context.WithCancel(context.Background())
+        m := &SessionManager{
+                baseDir: baseDir,
+                logger:  logger,
+                queue:   make(chan sessionRequest, 100),
+                active:  make(map[string]*Session),
+                sem:     make(chan struct{}, concurrency),
+                ctx:     ctx,
+                cancel:  cancel,
+                cfg:     cfg,
+                hist:    hist,
+        }
 	go m.dispatch()
 	return m
 }
@@ -88,13 +94,16 @@ func (m *SessionManager) dispatch() {
 
 // run executes a session and tracks it until completion.
 func (m *SessionManager) run(req sessionRequest) {
-	ctx, cancel := context.WithCancel(m.ctx)
-	cmd := exec.CommandContext(ctx, req.model, req.args...)
-	sess := &Session{ID: req.id, Model: req.model, Cmd: cmd, cancel: cancel, done: make(chan error, 1)}
-	m.logger.Info(fmt.Sprintf("session %s running model %s", req.id, req.model))
-	m.mu.Lock()
-	m.active[req.id] = sess
-	m.mu.Unlock()
+        ctx, cancel := context.WithCancel(m.ctx)
+        cmd := exec.CommandContext(ctx, req.model, req.args...)
+        var buf bytes.Buffer
+        cmd.Stdout = &buf
+        cmd.Stderr = &buf
+        sess := &Session{ID: req.id, Model: req.model, Prompt: req.prompt, Cmd: cmd, cancel: cancel, done: make(chan error, 1)}
+        m.logger.Info(fmt.Sprintf("session %s running model %s", req.id, req.model))
+        m.mu.Lock()
+        m.active[req.id] = sess
+        m.mu.Unlock()
 
 	if err := cmd.Start(); err != nil {
 		m.logger.Error(fmt.Sprintf("start %s: %v", req.id, err))
@@ -110,14 +119,26 @@ func (m *SessionManager) run(req sessionRequest) {
 	} else {
 		m.logger.Error(fmt.Sprintf("session %s monitor: %v", req.id, err))
 	}
-	go func() {
-		err := cmd.Wait()
-		sess.done <- err
-		m.logger.Info(fmt.Sprintf("session %s finished", req.id))
-		m.remove(req.id)
-		<-m.sem
-	}()
-	req.res <- nil
+        go func() {
+                err := cmd.Wait()
+                sess.done <- err
+                m.logger.Info(fmt.Sprintf("session %s finished", req.id))
+                if m.hist != nil {
+                        rec := history.Record{
+                                ID:        req.id,
+                                Prompt:    req.prompt,
+                                Response:  buf.String(),
+                                Model:     req.model,
+                                Success:   err == nil,
+                        }
+                        if err := m.hist.Add(rec); err != nil {
+                                m.logger.Error("history add " + err.Error())
+                        }
+                }
+                m.remove(req.id)
+                <-m.sem
+        }()
+        req.res <- nil
 }
 
 func (m *SessionManager) monitor(s *Session) {
@@ -162,13 +183,13 @@ func (m *SessionManager) remove(id string) {
 }
 
 // AddSession queues a CLI invocation and returns its ID when scheduled.
-func (m *SessionManager) AddSession(model string, args []string) (string, error) {
+func (m *SessionManager) AddSession(model, prompt string, args []string) (string, error) {
 	id, err := newUUID()
 	if err != nil {
 		return "", err
 	}
-	res := make(chan error, 1)
-	req := sessionRequest{id: id, model: model, args: args, res: res}
+        res := make(chan error, 1)
+        req := sessionRequest{id: id, model: model, prompt: prompt, args: args, res: res}
 	select {
 	case m.queue <- req:
 	case <-time.After(5 * time.Second):

--- a/internal/app/session_manager_test.go
+++ b/internal/app/session_manager_test.go
@@ -1,26 +1,29 @@
 package app
 
 import (
-	"path/filepath"
-	"testing"
-	"time"
+        "path/filepath"
+        "testing"
+        "time"
 
-	"cli-wrapper/internal/logging"
+        "cli-wrapper/internal/history"
+        "cli-wrapper/internal/logging"
 )
 
 func TestSessionManagerQueue(t *testing.T) {
 	logger, _ := logging.NewWithPath(filepath.Join(t.TempDir(), "log.txt"))
 	defer logger.Close()
-	cfg := &Config{Concurrency: 1, CPUThreshold: 50, MemoryThreshold: 50, PollInterval: 1}
-	m := NewSessionManager(t.TempDir(), logger, 1, cfg)
+        cfg := &Config{Concurrency: 1, CPUThreshold: 50, MemoryThreshold: 50, PollInterval: 1}
+        hist, _ := history.New(t.TempDir())
+        defer hist.Close()
+        m := NewSessionManager(t.TempDir(), logger, 1, cfg, hist)
 	defer m.Close()
 
 	start := time.Now()
-	id1, err := m.AddSession("sh", []string{"-c", "sleep 0.1"})
+        id1, err := m.AddSession("sh", "", []string{"-c", "sleep 0.1"})
 	if err != nil {
 		t.Fatalf("add1: %v", err)
 	}
-	id2, err := m.AddSession("sh", []string{"-c", "sleep 0.1"})
+        id2, err := m.AddSession("sh", "", []string{"-c", "sleep 0.1"})
 	if err != nil {
 		t.Fatalf("add2: %v", err)
 	}
@@ -38,11 +41,13 @@ func TestSessionManagerQueue(t *testing.T) {
 func TestSessionTerminate(t *testing.T) {
 	logger, _ := logging.NewWithPath(filepath.Join(t.TempDir(), "log.txt"))
 	defer logger.Close()
-	cfg := &Config{Concurrency: 1, CPUThreshold: 50, MemoryThreshold: 50, PollInterval: 1}
-	m := NewSessionManager(t.TempDir(), logger, 1, cfg)
+        cfg := &Config{Concurrency: 1, CPUThreshold: 50, MemoryThreshold: 50, PollInterval: 1}
+        hist, _ := history.New(t.TempDir())
+        defer hist.Close()
+        m := NewSessionManager(t.TempDir(), logger, 1, cfg, hist)
 	defer m.Close()
 
-	id, err := m.AddSession("sh", []string{"-c", "sleep 2"})
+        id, err := m.AddSession("sh", "", []string{"-c", "sleep 2"})
 	if err != nil {
 		t.Fatalf("add: %v", err)
 	}

--- a/internal/app/wails_backend.go
+++ b/internal/app/wails_backend.go
@@ -39,7 +39,7 @@ func (b *Backend) RunPrompt(model, prompt string) (string, error) {
 		_ = b.logger.ModelSwitch(b.lastModel, model, prompt)
 	}
 	b.lastModel = model
-	id, err := b.mgr.AddSession(model, []string{prompt})
+        id, err := b.mgr.AddSession(model, prompt, []string{prompt})
 	if err != nil {
 		return "", err
 	}

--- a/internal/history/store.go
+++ b/internal/history/store.go
@@ -1,0 +1,172 @@
+package history
+
+import (
+    "database/sql"
+    "encoding/json"
+    "fmt"
+    "path/filepath"
+    "time"
+
+    _ "modernc.org/sqlite"
+)
+
+type Record struct {
+    ID        string `json:"id"`
+    Prompt    string `json:"prompt"`
+    Response  string `json:"response"`
+    Model     string `json:"model"`
+    Timestamp string `json:"timestamp"`
+    Success   bool   `json:"success"`
+}
+
+type Store struct {
+    db *sql.DB
+}
+
+func New(baseDir string) (*Store, error) {
+    path := filepath.Join(baseDir, "state", "history.db")
+    db, err := sql.Open("sqlite", path+"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)")
+    if err != nil {
+        return nil, fmt.Errorf("open db: %w", err)
+    }
+    if err := initSchema(db); err != nil {
+        db.Close()
+        return nil, err
+    }
+    return &Store{db: db}, nil
+}
+
+func initSchema(db *sql.DB) error {
+    schema := `
+CREATE TABLE IF NOT EXISTS history(
+    id TEXT PRIMARY KEY,
+    prompt TEXT NOT NULL,
+    response TEXT NOT NULL,
+    model TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+    success INTEGER NOT NULL
+);
+CREATE VIRTUAL TABLE IF NOT EXISTS history_fts USING fts5(prompt, response, content='history', content_rowid='rowid');
+CREATE TRIGGER IF NOT EXISTS history_ai AFTER INSERT ON history BEGIN
+    INSERT INTO history_fts(rowid,prompt,response) VALUES(new.rowid,new.prompt,new.response);
+END;
+CREATE TRIGGER IF NOT EXISTS history_ad AFTER DELETE ON history BEGIN
+    INSERT INTO history_fts(history_fts,rowid,prompt,response) VALUES('delete',old.rowid,old.prompt,old.response);
+END;
+CREATE TRIGGER IF NOT EXISTS history_au AFTER UPDATE ON history BEGIN
+    INSERT INTO history_fts(history_fts,rowid,prompt,response) VALUES('delete',old.rowid,old.prompt,old.response);
+    INSERT INTO history_fts(rowid,prompt,response) VALUES(new.rowid,new.prompt,new.response);
+END;`
+    if _, err := db.Exec(schema); err != nil {
+        return fmt.Errorf("init schema: %w", err)
+    }
+    return nil
+}
+
+func (s *Store) Close() error {
+    return s.db.Close()
+}
+
+func boolToInt(b bool) int {
+    if b {
+        return 1
+    }
+    return 0
+}
+
+func intToBool(i int) bool {
+    return i != 0
+}
+
+func (s *Store) Add(r Record) error {
+    if r.ID == "" {
+        return fmt.Errorf("id required")
+    }
+    if r.Timestamp == "" {
+        r.Timestamp = time.Now().UTC().Format(time.RFC3339)
+    }
+    _, err := s.db.Exec(`INSERT INTO history(id,prompt,response,model,timestamp,success) VALUES(?,?,?,?,?,?)`,
+        r.ID, r.Prompt, r.Response, r.Model, r.Timestamp, boolToInt(r.Success))
+    if err != nil {
+        return fmt.Errorf("insert: %w", err)
+    }
+    return nil
+}
+
+func scanRows(rows *sql.Rows) ([]Record, error) {
+    var recs []Record
+    for rows.Next() {
+        var r Record
+        var success int
+        if err := rows.Scan(&r.ID, &r.Prompt, &r.Response, &r.Model, &r.Timestamp, &success); err != nil {
+            return nil, fmt.Errorf("scan: %w", err)
+        }
+        r.Success = intToBool(success)
+        recs = append(recs, r)
+    }
+    return recs, nil
+}
+
+func (s *Store) All() ([]Record, error) {
+    rows, err := s.db.Query(`SELECT id,prompt,response,model,timestamp,success FROM history ORDER BY timestamp DESC`)
+    if err != nil {
+        return nil, fmt.Errorf("query: %w", err)
+    }
+    defer rows.Close()
+    return scanRows(rows)
+}
+
+func (s *Store) Search(q string, limit int) ([]Record, error) {
+    if limit <= 0 {
+        limit = 20
+    }
+    rows, err := s.db.Query(`SELECT id,prompt,response,model,timestamp,success FROM history WHERE rowid IN (SELECT rowid FROM history_fts WHERE history_fts MATCH ? LIMIT ?) ORDER BY timestamp DESC`, q, limit)
+    if err != nil {
+        return nil, fmt.Errorf("search: %w", err)
+    }
+    defer rows.Close()
+    return scanRows(rows)
+}
+
+func (s *Store) Export() ([]byte, error) {
+    recs, err := s.All()
+    if err != nil {
+        return nil, err
+    }
+    data, err := json.MarshalIndent(recs, "", "  ")
+    if err != nil {
+        return nil, fmt.Errorf("marshal: %w", err)
+    }
+    return data, nil
+}
+
+func (s *Store) Import(data []byte) error {
+    var recs []Record
+    if err := json.Unmarshal(data, &recs); err != nil {
+        return fmt.Errorf("unmarshal: %w", err)
+    }
+    tx, err := s.db.Begin()
+    if err != nil {
+        return fmt.Errorf("begin: %w", err)
+    }
+    stmt, err := tx.Prepare(`INSERT OR REPLACE INTO history(id,prompt,response,model,timestamp,success) VALUES(?,?,?,?,?,?)`)
+    if err != nil {
+        tx.Rollback()
+        return fmt.Errorf("prepare: %w", err)
+    }
+    defer stmt.Close()
+    for _, r := range recs {
+        if r.Timestamp == "" {
+            r.Timestamp = time.Now().UTC().Format(time.RFC3339)
+        }
+        if _, err := stmt.Exec(r.ID, r.Prompt, r.Response, r.Model, r.Timestamp, boolToInt(r.Success)); err != nil {
+            tx.Rollback()
+            return fmt.Errorf("exec: %w", err)
+        }
+    }
+    if err := tx.Commit(); err != nil {
+        return fmt.Errorf("commit: %w", err)
+    }
+    return nil
+}
+

--- a/internal/history/store_test.go
+++ b/internal/history/store_test.go
@@ -1,0 +1,50 @@
+package history
+
+import (
+    "encoding/json"
+    "testing"
+)
+
+func TestStoreCRUD(t *testing.T) {
+    dir := t.TempDir()
+    s, err := New(dir)
+    if err != nil {
+        t.Fatalf("new store: %v", err)
+    }
+    defer s.Close()
+
+    r := Record{ID: "1", Prompt: "hi", Response: "hello", Model: "openai", Success: true}
+    if err := s.Add(r); err != nil {
+        t.Fatalf("add: %v", err)
+    }
+    all, err := s.All()
+    if err != nil || len(all) != 1 {
+        t.Fatalf("all: %v len=%d", err, len(all))
+    }
+
+    res, err := s.Search("hello", 10)
+    if err != nil || len(res) == 0 {
+        t.Fatalf("search: %v len=%d", err, len(res))
+    }
+
+    data, err := s.Export()
+    if err != nil {
+        t.Fatalf("export: %v", err)
+    }
+
+    // import into new store
+    s2, err := New(t.TempDir())
+    if err != nil {
+        t.Fatalf("new2: %v", err)
+    }
+    defer s2.Close()
+    if err := s2.Import(data); err != nil {
+        t.Fatalf("import: %v", err)
+    }
+    all2, _ := s2.All()
+    if len(all2) != 1 {
+        b, _ := json.Marshal(all2)
+        t.Fatalf("imported len=%d data=%s", len(all2), string(b))
+    }
+}
+

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,35 +1,41 @@
 package server
 
 import (
-	"encoding/json"
-	"net/http"
+        "encoding/json"
+        "io"
+        "net/http"
 
-	"cli-wrapper/internal/app"
-	"cli-wrapper/internal/logging"
-	"cli-wrapper/internal/telemetry"
+        "cli-wrapper/internal/app"
+        "cli-wrapper/internal/history"
+        "cli-wrapper/internal/logging"
+        "cli-wrapper/internal/telemetry"
 )
 
 // Server exposes HTTP endpoints for the frontend.
 type Server struct {
-	mgr     *app.SessionManager
-	logger  *logging.Logger
-	baseDir string
-	cfg     *app.Config
-	mux     *http.ServeMux
+        mgr     *app.SessionManager
+        logger  *logging.Logger
+        baseDir string
+        cfg     *app.Config
+        mux     *http.ServeMux
+        hist    *history.Store
 }
 
 // New creates a Server with its routes configured.
-func New(mgr *app.SessionManager, logger *logging.Logger, baseDir string, cfg *app.Config) *Server {
-	s := &Server{mgr: mgr, logger: logger, baseDir: baseDir, cfg: cfg, mux: http.NewServeMux()}
+func New(mgr *app.SessionManager, logger *logging.Logger, baseDir string, cfg *app.Config, hist *history.Store) *Server {
+        s := &Server{mgr: mgr, logger: logger, baseDir: baseDir, cfg: cfg, hist: hist, mux: http.NewServeMux()}
 	s.routes()
 	return s
 }
 
 func (s *Server) routes() {
-	s.mux.HandleFunc("/sessions", s.handleSessions)
-	s.mux.HandleFunc("/resource", s.handleResource)
-	s.mux.HandleFunc("/models", s.handleModels)
-	s.mux.HandleFunc("/theme", s.handleTheme)
+        s.mux.HandleFunc("/sessions", s.handleSessions)
+        s.mux.HandleFunc("/resource", s.handleResource)
+        s.mux.HandleFunc("/models", s.handleModels)
+        s.mux.HandleFunc("/theme", s.handleTheme)
+        s.mux.HandleFunc("/history", s.handleHistory)
+        s.mux.HandleFunc("/history/search", s.handleHistorySearch)
+        s.mux.HandleFunc("/history/export", s.handleHistoryExport)
 }
 
 func (s *Server) respondJSON(w http.ResponseWriter, v any) {
@@ -86,7 +92,56 @@ func (s *Server) handleTheme(w http.ResponseWriter, r *http.Request) {
 		s.respondJSON(w, map[string]string{"theme": s.cfg.Theme})
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-	}
+        }
+}
+
+func (s *Server) handleHistory(w http.ResponseWriter, r *http.Request) {
+        switch r.Method {
+        case http.MethodGet:
+                recs, err := s.hist.All()
+                if err != nil {
+                        s.logger.Error("history all: " + err.Error())
+                        http.Error(w, "internal", http.StatusInternalServerError)
+                        return
+                }
+                s.respondJSON(w, recs)
+        case http.MethodPost:
+                data, err := io.ReadAll(r.Body)
+                if err != nil {
+                        http.Error(w, "bad request", http.StatusBadRequest)
+                        return
+                }
+                if err := s.hist.Import(data); err != nil {
+                        s.logger.Error("import history: " + err.Error())
+                        http.Error(w, "internal", http.StatusInternalServerError)
+                        return
+                }
+                s.respondJSON(w, map[string]string{"status": "ok"})
+        default:
+                http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+        }
+}
+
+func (s *Server) handleHistorySearch(w http.ResponseWriter, r *http.Request) {
+        q := r.URL.Query().Get("q")
+        recs, err := s.hist.Search(q, 20)
+        if err != nil {
+                s.logger.Error("search history: " + err.Error())
+                http.Error(w, "internal", http.StatusInternalServerError)
+                return
+        }
+        s.respondJSON(w, recs)
+}
+
+func (s *Server) handleHistoryExport(w http.ResponseWriter, r *http.Request) {
+        data, err := s.hist.Export()
+        if err != nil {
+                s.logger.Error("export history: " + err.Error())
+                http.Error(w, "internal", http.StatusInternalServerError)
+                return
+        }
+        w.Header().Set("Content-Type", "application/json")
+        _, _ = w.Write(data)
 }
 
 // Start listens on the given address.


### PR DESCRIPTION
## Summary
- add SQLite-based history store with FTS5 search
- log prompts and responses in `SessionManager`
- expose history endpoints in HTTP server
- wire store into server and Wails app
- create React component to view, search, export and import history

## Testing
- `go vet ./...` *(fails: modernc.org/sqlite, wails)*
- `go test ./...` *(fails: modernc.org/sqlite, wails)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686118d136e0832a9d5bde90a7f6a02e