### PR TITLE
Add billing endpoint with usage info

### DIFF
--- a/internal/app/billing.go
+++ b/internal/app/billing.go
@@ -1,0 +1,55 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+)
+
+// BillingUsage holds credit usage information returned by the CLI.
+type BillingUsage struct {
+	TotalGranted   float64 `json:"total_granted"`
+	TotalUsed      float64 `json:"total_used"`
+	TotalAvailable float64 `json:"total_available"`
+}
+
+// BillingURL returns the billing page URL for the given CLI tool.
+func BillingURL(tool string) (string, error) {
+	switch tool {
+	case "openai":
+		return "https://platform.openai.com/account/billing", nil
+	case "gemini":
+		return "https://makersuite.google.com/app/apikey", nil
+	default:
+		return "", fmt.Errorf("unknown tool %q", tool)
+	}
+}
+
+// FetchUsage executes the CLI to retrieve usage information if supported.
+// It returns an error if the CLI does not provide usage details.
+func FetchUsage(tool string) (*BillingUsage, error) {
+	switch tool {
+	case "openai":
+		out, err := exec.Command("openai", "api", "request", "GET", "/dashboard/billing/credit_grants").Output()
+		if err != nil {
+			return nil, fmt.Errorf("openai usage: %w", err)
+		}
+		var res BillingUsage
+		if err := json.Unmarshal(out, &res); err != nil {
+			return nil, fmt.Errorf("parse openai usage: %w", err)
+		}
+		return &res, nil
+	case "gemini":
+		out, err := exec.Command("gemini", "usage").Output()
+		if err != nil {
+			return nil, fmt.Errorf("gemini usage: %w", err)
+		}
+		var res BillingUsage
+		if err := json.Unmarshal(out, &res); err != nil {
+			return nil, fmt.Errorf("parse gemini usage: %w", err)
+		}
+		return &res, nil
+	default:
+		return nil, fmt.Errorf("unsupported tool %q", tool)
+	}
+}

--- a/internal/app/billing_test.go
+++ b/internal/app/billing_test.go
@@ -1,0 +1,46 @@
+package app
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBillingURL(t *testing.T) {
+	url, err := BillingURL("openai")
+	if err != nil || url == "" {
+		t.Fatalf("openai billing url err=%v url=%s", err, url)
+	}
+	url, err = BillingURL("gemini")
+	if err != nil || url == "" {
+		t.Fatalf("gemini billing url err=%v url=%s", err, url)
+	}
+	if _, err := BillingURL("foo"); err == nil {
+		t.Fatal("expected error for unknown tool")
+	}
+}
+
+func TestFetchUsage(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "openai")
+	content := "#!/bin/sh\necho '{\"total_granted\":100,\"total_used\":50,\"total_available\":50}'"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	oldPath := os.Getenv("PATH")
+	os.Setenv("PATH", dir+string(os.PathListSeparator)+oldPath)
+	defer os.Setenv("PATH", oldPath)
+
+	u, err := FetchUsage("openai")
+	if err != nil {
+		t.Fatalf("fetch usage: %v", err)
+	}
+	if u.TotalGranted != 100 || u.TotalUsed != 50 || u.TotalAvailable != 50 {
+		b, _ := json.Marshal(u)
+		t.Fatalf("unexpected usage %s", b)
+	}
+	if _, err := FetchUsage("unknown"); err == nil {
+		t.Fatal("expected error for unknown tool")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,41 +1,42 @@
 package server
 
 import (
-        "encoding/json"
-        "io"
-        "net/http"
+	"encoding/json"
+	"io"
+	"net/http"
 
-        "cli-wrapper/internal/app"
-        "cli-wrapper/internal/history"
-        "cli-wrapper/internal/logging"
-        "cli-wrapper/internal/telemetry"
+	"cli-wrapper/internal/app"
+	"cli-wrapper/internal/history"
+	"cli-wrapper/internal/logging"
+	"cli-wrapper/internal/telemetry"
 )
 
 // Server exposes HTTP endpoints for the frontend.
 type Server struct {
-        mgr     *app.SessionManager
-        logger  *logging.Logger
-        baseDir string
-        cfg     *app.Config
-        mux     *http.ServeMux
-        hist    *history.Store
+	mgr     *app.SessionManager
+	logger  *logging.Logger
+	baseDir string
+	cfg     *app.Config
+	mux     *http.ServeMux
+	hist    *history.Store
 }
 
 // New creates a Server with its routes configured.
 func New(mgr *app.SessionManager, logger *logging.Logger, baseDir string, cfg *app.Config, hist *history.Store) *Server {
-        s := &Server{mgr: mgr, logger: logger, baseDir: baseDir, cfg: cfg, hist: hist, mux: http.NewServeMux()}
+	s := &Server{mgr: mgr, logger: logger, baseDir: baseDir, cfg: cfg, hist: hist, mux: http.NewServeMux()}
 	s.routes()
 	return s
 }
 
 func (s *Server) routes() {
-        s.mux.HandleFunc("/sessions", s.handleSessions)
-        s.mux.HandleFunc("/resource", s.handleResource)
-        s.mux.HandleFunc("/models", s.handleModels)
-        s.mux.HandleFunc("/theme", s.handleTheme)
-        s.mux.HandleFunc("/history", s.handleHistory)
-        s.mux.HandleFunc("/history/search", s.handleHistorySearch)
-        s.mux.HandleFunc("/history/export", s.handleHistoryExport)
+	s.mux.HandleFunc("/sessions", s.handleSessions)
+	s.mux.HandleFunc("/resource", s.handleResource)
+	s.mux.HandleFunc("/models", s.handleModels)
+	s.mux.HandleFunc("/billing", s.handleBilling)
+	s.mux.HandleFunc("/theme", s.handleTheme)
+	s.mux.HandleFunc("/history", s.handleHistory)
+	s.mux.HandleFunc("/history/search", s.handleHistorySearch)
+	s.mux.HandleFunc("/history/export", s.handleHistoryExport)
 }
 
 func (s *Server) respondJSON(w http.ResponseWriter, v any) {
@@ -92,56 +93,78 @@ func (s *Server) handleTheme(w http.ResponseWriter, r *http.Request) {
 		s.respondJSON(w, map[string]string{"theme": s.cfg.Theme})
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-        }
+	}
 }
 
 func (s *Server) handleHistory(w http.ResponseWriter, r *http.Request) {
-        switch r.Method {
-        case http.MethodGet:
-                recs, err := s.hist.All()
-                if err != nil {
-                        s.logger.Error("history all: " + err.Error())
-                        http.Error(w, "internal", http.StatusInternalServerError)
-                        return
-                }
-                s.respondJSON(w, recs)
-        case http.MethodPost:
-                data, err := io.ReadAll(r.Body)
-                if err != nil {
-                        http.Error(w, "bad request", http.StatusBadRequest)
-                        return
-                }
-                if err := s.hist.Import(data); err != nil {
-                        s.logger.Error("import history: " + err.Error())
-                        http.Error(w, "internal", http.StatusInternalServerError)
-                        return
-                }
-                s.respondJSON(w, map[string]string{"status": "ok"})
-        default:
-                http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-        }
+	switch r.Method {
+	case http.MethodGet:
+		recs, err := s.hist.All()
+		if err != nil {
+			s.logger.Error("history all: " + err.Error())
+			http.Error(w, "internal", http.StatusInternalServerError)
+			return
+		}
+		s.respondJSON(w, recs)
+	case http.MethodPost:
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if err := s.hist.Import(data); err != nil {
+			s.logger.Error("import history: " + err.Error())
+			http.Error(w, "internal", http.StatusInternalServerError)
+			return
+		}
+		s.respondJSON(w, map[string]string{"status": "ok"})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
 }
 
 func (s *Server) handleHistorySearch(w http.ResponseWriter, r *http.Request) {
-        q := r.URL.Query().Get("q")
-        recs, err := s.hist.Search(q, 20)
-        if err != nil {
-                s.logger.Error("search history: " + err.Error())
-                http.Error(w, "internal", http.StatusInternalServerError)
-                return
-        }
-        s.respondJSON(w, recs)
+	q := r.URL.Query().Get("q")
+	recs, err := s.hist.Search(q, 20)
+	if err != nil {
+		s.logger.Error("search history: " + err.Error())
+		http.Error(w, "internal", http.StatusInternalServerError)
+		return
+	}
+	s.respondJSON(w, recs)
 }
 
 func (s *Server) handleHistoryExport(w http.ResponseWriter, r *http.Request) {
-        data, err := s.hist.Export()
-        if err != nil {
-                s.logger.Error("export history: " + err.Error())
-                http.Error(w, "internal", http.StatusInternalServerError)
-                return
-        }
-        w.Header().Set("Content-Type", "application/json")
-        _, _ = w.Write(data)
+	data, err := s.hist.Export()
+	if err != nil {
+		s.logger.Error("export history: " + err.Error())
+		http.Error(w, "internal", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(data)
+}
+
+func (s *Server) handleBilling(w http.ResponseWriter, r *http.Request) {
+	tool, err := app.DetectCLITool()
+	if err != nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	url, err := app.BillingURL(tool)
+	if err != nil {
+		s.logger.Error("billing url: " + err.Error())
+		http.Error(w, "internal", http.StatusInternalServerError)
+		return
+	}
+	resp := map[string]any{
+		"tool": tool,
+		"url":  url,
+	}
+	if usage, err := app.FetchUsage(tool); err == nil {
+		resp["usage"] = usage
+	}
+	s.respondJSON(w, resp)
 }
 
 // Start listens on the given address.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,28 +1,28 @@
 package server
 
 import (
-        "bytes"
-        "encoding/json"
-        "net/http"
-        "net/http/httptest"
-        "path/filepath"
-        "testing"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
 
-        "cli-wrapper/internal/app"
-        "cli-wrapper/internal/history"
-        "cli-wrapper/internal/logging"
+	"cli-wrapper/internal/app"
+	"cli-wrapper/internal/history"
+	"cli-wrapper/internal/logging"
 )
 
 func TestEndpoints(t *testing.T) {
 	dir := t.TempDir()
-        logger, _ := logging.NewWithPath(filepath.Join(dir, "log.txt"))
-        cfg := &app.Config{Concurrency: 1, Theme: "light", CPUThreshold: 50, MemoryThreshold: 50, PollInterval: 2}
-        hist, _ := history.New(dir)
-        defer hist.Close()
-        mgr := app.NewSessionManager(dir, logger, 1, cfg, hist)
-        defer mgr.Close()
+	logger, _ := logging.NewWithPath(filepath.Join(dir, "log.txt"))
+	cfg := &app.Config{Concurrency: 1, Theme: "light", CPUThreshold: 50, MemoryThreshold: 50, PollInterval: 2}
+	hist, _ := history.New(dir)
+	defer hist.Close()
+	mgr := app.NewSessionManager(dir, logger, 1, cfg, hist)
+	defer mgr.Close()
 
-        srv := New(mgr, logger, dir, cfg, hist)
+	srv := New(mgr, logger, dir, cfg, hist)
 	ts := httptest.NewServer(srv.mux)
 	defer ts.Close()
 
@@ -73,41 +73,67 @@ func TestEndpoints(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&themeResp); err != nil {
 		t.Fatalf("decode post theme: %v", err)
 	}
-        if themeResp["theme"] != "dark" {
-                t.Fatalf("got %s want dark", themeResp["theme"])
-        }
+	if themeResp["theme"] != "dark" {
+		t.Fatalf("got %s want dark", themeResp["theme"])
+	}
 
-        // history endpoints
-        data := `[{"id":"1","prompt":"hi","response":"hello","model":"openai","success":true}]`
-        resp, err = http.Post(ts.URL+"/history", "application/json", bytes.NewBufferString(data))
-        if err != nil || resp.StatusCode != http.StatusOK {
-                t.Fatalf("import history: %v status %d", err, resp.StatusCode)
-        }
+	// history endpoints
+	data := `[{"id":"1","prompt":"hi","response":"hello","model":"openai","success":true}]`
+	resp, err = http.Post(ts.URL+"/history", "application/json", bytes.NewBufferString(data))
+	if err != nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("import history: %v status %d", err, resp.StatusCode)
+	}
 
-        resp, err = http.Get(ts.URL + "/history")
-        if err != nil {
-                t.Fatalf("get history: %v", err)
-        }
-        var recs []history.Record
-        if err := json.NewDecoder(resp.Body).Decode(&recs); err != nil || len(recs) != 1 {
-                t.Fatalf("decode history: %v len=%d", err, len(recs))
-        }
+	resp, err = http.Get(ts.URL + "/history")
+	if err != nil {
+		t.Fatalf("get history: %v", err)
+	}
+	var recs []history.Record
+	if err := json.NewDecoder(resp.Body).Decode(&recs); err != nil || len(recs) != 1 {
+		t.Fatalf("decode history: %v len=%d", err, len(recs))
+	}
 
-        resp, err = http.Get(ts.URL + "/history/search?q=hello")
-        if err != nil {
-                t.Fatalf("search history: %v", err)
-        }
-        var recs2 []history.Record
-        if err := json.NewDecoder(resp.Body).Decode(&recs2); err != nil || len(recs2) == 0 {
-                t.Fatalf("search decode: %v len=%d", err, len(recs2))
-        }
+	resp, err = http.Get(ts.URL + "/history/search?q=hello")
+	if err != nil {
+		t.Fatalf("search history: %v", err)
+	}
+	var recs2 []history.Record
+	if err := json.NewDecoder(resp.Body).Decode(&recs2); err != nil || len(recs2) == 0 {
+		t.Fatalf("search decode: %v len=%d", err, len(recs2))
+	}
 
-        resp, err = http.Get(ts.URL + "/history/export")
-        if err != nil {
-                t.Fatalf("export history: %v", err)
-        }
-        var exp []history.Record
-        if err := json.NewDecoder(resp.Body).Decode(&exp); err != nil || len(exp) != 1 {
-                t.Fatalf("export decode: %v len=%d", err, len(exp))
-        }
+	resp, err = http.Get(ts.URL + "/history/export")
+	if err != nil {
+		t.Fatalf("export history: %v", err)
+	}
+	var exp []history.Record
+	if err := json.NewDecoder(resp.Body).Decode(&exp); err != nil || len(exp) != 1 {
+		t.Fatalf("export decode: %v len=%d", err, len(exp))
+	}
+
+	// billing endpoint using stubbed CLI
+	script := filepath.Join(dir, "openai")
+	content := "#!/bin/sh\necho '{\"total_granted\":1}'"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	oldPath := os.Getenv("PATH")
+	os.Setenv("PATH", dir+string(os.PathListSeparator)+oldPath)
+	defer os.Setenv("PATH", oldPath)
+
+	resp, err = http.Get(ts.URL + "/billing")
+	if err != nil {
+		t.Fatalf("billing: %v", err)
+	}
+	var billResp struct {
+		Tool  string           `json:"tool"`
+		URL   string           `json:"url"`
+		Usage app.BillingUsage `json:"usage"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&billResp); err != nil {
+		t.Fatalf("decode billing: %v", err)
+	}
+	if billResp.Tool != "openai" || billResp.URL == "" || billResp.Usage.TotalGranted != 1 {
+		t.Fatalf("unexpected billing response %#v", billResp)
+	}
 }


### PR DESCRIPTION
## Summary
- detect billing URL based on active CLI
- return usage stats if available
- expose new `/billing` HTTP endpoint and tests

## Testing
- `go vet ./...` *(fails: Forbidden accessing storage.googleapis.com)*
- `go test -race ./...` *(fails: Forbidden accessing storage.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_68611b57df18832a998beed3ba8b5bb1