### PR TITLE
Secure input handling & CI analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+on:
+  push:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm ci
+        working-directory: frontend
+      - run: npm test --if-present
+        working-directory: frontend
+      - run: npm audit --audit-level=high
+        working-directory: frontend
+      - run: go vet ./...
+      - run: go test -race ./...
+      - run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+      - run: gosec ./...
+      - run: wails build -platform windows/amd64
+      - run: wails build -platform darwin/universal
+      - run: wails build -platform linux/amd64
+      - run: scripts/sign.sh build/bin/*
+        env:
+          SIGN_KEY: ${{ secrets.SIGN_KEY }}
+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { EventsOn } from "@wailsio/runtime";
+import { maskSecrets } from "./utils";
 
 declare global {
   interface Window {
@@ -35,7 +36,7 @@ function App() {
 
   const send = async () => {
     const res = await window.backend.RunPrompt(model, prompt);
-    setResponse(res);
+    setResponse(maskSecrets(res));
   };
 
   return (

--- a/frontend/src/components/HistoryViewer.tsx
+++ b/frontend/src/components/HistoryViewer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, ChangeEvent } from "react";
+import { maskSecrets } from "../utils";
 
 interface Record {
   id: string;
@@ -61,8 +62,8 @@ export default function HistoryViewer() {
       <ul className="space-y-1 overflow-y-auto" style={{ maxHeight: "200px" }}>
         {records.map((r) => (
           <li key={r.id} className="text-sm">
-            <div className="font-mono">{r.prompt}</div>
-            <div className="text-gray-500 truncate">{r.response}</div>
+            <div className="font-mono">{maskSecrets(r.prompt)}</div>
+            <div className="text-gray-500 truncate">{maskSecrets(r.response)}</div>
           </li>
         ))}
       </ul>

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,0 +1,4 @@
+export function maskSecrets(text: string): string {
+  const apiKeyPattern = /(sk-[a-zA-Z0-9]{10,})/g;
+  return text.replace(apiKeyPattern, (m) => '*'.repeat(m.length));
+}

--- a/internal/app/sanitize.go
+++ b/internal/app/sanitize.go
@@ -1,0 +1,29 @@
+package app
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var modelPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// SanitizeModel validates allowed characters in model names.
+func SanitizeModel(model string) (string, error) {
+	if !modelPattern.MatchString(model) {
+		return "", fmt.Errorf("invalid model name")
+	}
+	return model, nil
+}
+
+// SanitizePrompt removes control characters and leading dashes to avoid argument injection.
+func SanitizePrompt(p string) string {
+	p = strings.ReplaceAll(p, "\n", " ")
+	p = strings.ReplaceAll(p, "\r", " ")
+	p = strings.TrimSpace(p)
+	for strings.HasPrefix(p, "-") {
+		p = strings.TrimPrefix(p, "-")
+		p = "_" + p
+	}
+	return p
+}

--- a/internal/app/sanitize_test.go
+++ b/internal/app/sanitize_test.go
@@ -1,0 +1,26 @@
+package app
+
+import "testing"
+
+func TestSanitizePrompt(t *testing.T) {
+	cases := []struct{ in, out string }{
+		{"hello", "hello"},
+		{"-danger", "_danger"},
+		{"\ntrim\r", "trim"},
+	}
+	for _, c := range cases {
+		got := SanitizePrompt(c.in)
+		if got != c.out {
+			t.Errorf("expected %q got %q", c.out, got)
+		}
+	}
+}
+
+func TestSanitizeModel(t *testing.T) {
+	if _, err := SanitizeModel("../bad"); err == nil {
+		t.Error("expected error")
+	}
+	if m, err := SanitizeModel("good-model_1"); err != nil || m != "good-model_1" {
+		t.Errorf("unexpected result %v %v", m, err)
+	}
+}

--- a/internal/app/wails_backend.go
+++ b/internal/app/wails_backend.go
@@ -32,6 +32,12 @@ func (b *Backend) RunPrompt(model, prompt string) (string, error) {
 	if model == "" {
 		return "", fmt.Errorf("model required")
 	}
+	var err error
+	model, err = SanitizeModel(model)
+	if err != nil {
+		return "", err
+	}
+	prompt = SanitizePrompt(prompt)
 	if b.lastModel != "" && model != b.lastModel {
 		if b.cfg.ModelAlerts {
 			runtime.EventsEmit(b.ctx, "model:switched", map[string]string{"from": b.lastModel, "to": model})
@@ -39,7 +45,7 @@ func (b *Backend) RunPrompt(model, prompt string) (string, error) {
 		_ = b.logger.ModelSwitch(b.lastModel, model, prompt)
 	}
 	b.lastModel = model
-        id, err := b.mgr.AddSession(model, prompt, []string{prompt})
+	id, err := b.mgr.AddSession(model, prompt, []string{prompt})
 	if err != nil {
 		return "", err
 	}

--- a/scripts/sign.sh
+++ b/scripts/sign.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+if [ -z "$SIGN_KEY" ]; then
+  echo "SIGN_KEY not set" >&2
+  exit 1
+fi
+for f in "$@"; do
+  gpg --batch --yes --armor --local-user "$SIGN_KEY" --output "$f.asc" --detach-sign "$f"
+done


### PR DESCRIPTION
## Summary
- sanitize prompts and model names before invoking CLIs
- mask API keys in frontend displays
- add GPG signing script for build artifacts
- integrate gosec and npm audit into CI

## Testing
- `go vet ./...` *(fails: storage.googleapis.com Forbidden)*
- `go test ./...` *(fails: storage.googleapis.com Forbidden)*
- `npm --prefix frontend audit --audit-level=high` *(fails: ENOLOCK)*

------
https://chatgpt.com/codex/tasks/task_e_68611ca942cc832a9f7025b18258f12f