### PR TITLE
Add frontend integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Run unit tests with:
 ```
 go vet ./...
 go test -race ./...
+npm test --prefix frontend
 ```
 
 ## Wails Application

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "scripts": {
     "build": "vite build",
-    "start": "vite dev"
+    "start": "vite dev",
+    "test": "vitest run"
   },
   "dependencies": {
     "react": "18.2.0",
@@ -16,6 +17,10 @@
     "@vitejs/plugin-react": "^4.0.0",
     "tailwindcss": "^3.4.0",
     "postcss": "^8.4.0",
-    "autoprefixer": "^10.4.0"
+    "autoprefixer": "^10.4.0",
+    "vitest": "^1.5.1",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^5.17.0",
+    "jsdom": "^22.1.0"
   }
 }

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import App from '../App';
+
+const events: Record<string, (data: any) => void> = {};
+vi.mock('@wailsio/runtime', () => ({
+  EventsOn: (event: string, handler: (data: any) => void) => {
+    events[event] = handler;
+    return () => delete events[event];
+  },
+}));
+
+beforeAll(() => {
+  vi.stubGlobal('fetch', vi.fn());
+  (global as any).window.backend = { RunPrompt: vi.fn() };
+});
+
+beforeEach(() => {
+  (fetch as any).mockReset();
+  (window.backend.RunPrompt as any).mockReset();
+});
+
+describe('App logging', () => {
+  it('shows alert on model switch event', async () => {
+    render(<App />);
+
+    events['model:switched']?.({ from: 'old', to: 'new' });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Model switched from old to new');
+    });
+  });
+});

--- a/frontend/src/__tests__/SessionList.test.tsx
+++ b/frontend/src/__tests__/SessionList.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import SessionList from '../components/SessionList';
+import { vi } from 'vitest';
+
+vi.stubGlobal('fetch', vi.fn());
+
+describe('SessionList', () => {
+  beforeEach(() => {
+    ;(fetch as any).mockReset();
+  });
+
+  it('displays fetched session IDs', async () => {
+    (fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ['abc123', 'xyz789'],
+    });
+
+    render(<SessionList />);
+
+    await waitFor(() => {
+      expect(screen.getByText('abc123')).toBeInTheDocument();
+      expect(screen.getByText('xyz789')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,4 +3,9 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/test/setup.ts',
+  },
 });


### PR DESCRIPTION
## Summary
- add integration tests for React components
- configure Vitest test setup and dependencies
- document `npm test` usage

## Testing
- `npm test --prefix frontend` *(fails: vitest not found)*
- `go vet ./...` *(fails: Forbidden for modules)*
- `go test -race ./...` *(fails: Forbidden for modules)*
- `gosec ./...` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686142b8fe84832abaa9644a21ae984f