### PR TITLE
Update docs with sprint progress and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This repository contains helper utilities for the CLI Wrapper project.
 
+See [docs/ROADMAP.md](docs/ROADMAP.md) for the full project plan and
+[docs/DASHBOARD.md](docs/DASHBOARD.md) for current sprint status.
+
 ## `phasefirst` Command
 
 The `phasefirst` command extracts the first bullet from the **Detailed Steps**

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -1,0 +1,16 @@
+# Project Dashboard
+
+This dashboard summarizes sprint completion across all phases.
+
+| Phase | Sprint | Key Tasks | Status |
+|------|--------|-----------|--------|
+| 01 | 1 | Core application foundation | ✅ Done |
+| 02 | 2 | Session manager with concurrency limits | ✅ Done |
+| 03 | 3 | UI themes and metrics | ✅ Done |
+| 04 | 4 | Model switch alerts and logging | ✅ Done |
+| 05 | 5 | Resource throttling and telemetry | ✅ Done |
+| 06 | 6 | History persistence and search | ✅ Done |
+| 07 | 7 | Billing links and session summary | ✅ Done |
+| 08 | 8 | Security hardening and release signing | 🚧 In Progress |
+
+Progress is tracked per sprint. Phase 08 focuses on final polish and signing binaries.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,3 +12,18 @@ This project is delivered in eight phases. Each phase builds upon the previous o
 8. **Phase 08: Error Security and Polish** – hardens the application and finalizes the user experience. [Read more](phases/phase08_error_security_and_polish.md)
 
 Each document under `docs/phases/` contains detailed steps for implementation. Follow them sequentially to complete the project.
+
+## Phase Status
+
+| Phase | Status |
+|-------|--------|
+| 01 | ✅ Completed |
+| 02 | ✅ Completed |
+| 03 | ✅ Completed |
+| 04 | ✅ Completed |
+| 05 | ✅ Completed |
+| 06 | ✅ Completed |
+| 07 | ✅ Completed |
+| 08 | 🚧 In Progress |
+
+See [DASHBOARD.md](DASHBOARD.md) for sprint breakdowns.

--- a/docs/phases/phase01_core_app_foundation.md
+++ b/docs/phases/phase01_core_app_foundation.md
@@ -22,3 +22,12 @@ The application should launch successfully with one model available, create the 
 
 ## Dependencies
 None. This phase creates the foundation for all subsequent work.
+
+## Status
+Completed in **Sprint 1**.
+
+## Sprint Plan
+- [x] Scaffold the Wails project and React frontend
+- [x] Configure cross-platform directories and logging
+- [x] Detect available AI CLI tools
+- [x] Build the initial prompt and output interface

--- a/docs/phases/phase02_cli_session_manager.md
+++ b/docs/phases/phase02_cli_session_manager.md
@@ -17,3 +17,11 @@ Users can queue or run several prompts at once, manage sessions from the UI, and
 
 ## Dependencies
 Requires the core application foundation from Phase 01.
+
+## Status
+Completed in **Sprint 2**.
+
+## Sprint Plan
+- [x] Add concurrency control to manage running sessions
+- [x] Provide safe termination of processes
+- [x] Persist the session limit in configuration

--- a/docs/phases/phase03_stunning_ui_and_themes.md
+++ b/docs/phases/phase03_stunning_ui_and_themes.md
@@ -20,3 +20,11 @@ The interface feels modern and interactive. Theme preference is remembered, and 
 
 ## Dependencies
 Completion of Phase 02 for session handling.
+
+## Status
+Completed in **Sprint 3**.
+
+## Sprint Plan
+- [x] Add Tailwind styling and responsive layouts
+- [x] Implement dark and light themes
+- [x] Display CPU and memory usage metrics

--- a/docs/phases/phase04_model_change_alerts_and_logging.md
+++ b/docs/phases/phase04_model_change_alerts_and_logging.md
@@ -17,3 +17,11 @@ Users can easily identify which model was used for any prompt, both in the inter
 
 ## Dependencies
 Requires theme and layout groundwork from Phase 03.
+
+## Status
+Completed in **Sprint 4**.
+
+## Sprint Plan
+- [x] Persist model selections per session
+- [x] Emit alerts and log model switches
+- [x] Rotate logs automatically

--- a/docs/phases/phase05_resource_throttling_and_telemetry.md
+++ b/docs/phases/phase05_resource_throttling_and_telemetry.md
@@ -17,3 +17,11 @@ The application adapts to system load, keeps resource usage under control, and l
 
 ## Dependencies
 Builds on the session management from Phase 02 and logging from Phase 04.
+
+## Status
+Completed in **Sprint 5**.
+
+## Sprint Plan
+- [x] Read CPU and memory metrics with gopsutil
+- [x] Throttle or cancel overused sessions
+- [x] Persist thresholds in configuration

--- a/docs/phases/phase06_history_and_cli_logging.md
+++ b/docs/phases/phase06_history_and_cli_logging.md
@@ -16,3 +16,11 @@ Users have a complete searchable archive of all prompts and responses stored on 
 
 ## Dependencies
 Requires the resource throttling and telemetry from Phase 05.
+
+## Status
+Completed in **Sprint 6**.
+
+## Sprint Plan
+- [x] Store prompts and responses in SQLite
+- [x] Add search and re-run capabilities
+- [x] Support import and export of history

--- a/docs/phases/phase07_direct_billing_links_and_session_summary.md
+++ b/docs/phases/phase07_direct_billing_links_and_session_summary.md
@@ -17,3 +17,11 @@ Users can view their billing page with a single click and optionally monitor usa
 
 ## Dependencies
 Builds on previous phases to identify the CLI and store history data from Phase 06.
+
+## Status
+Completed in **Sprint 7**.
+
+## Sprint Plan
+- [x] Link to provider billing portals
+- [x] Show usage statistics when available
+- [x] Cache latest totals on startup

--- a/docs/phases/phase08_error_security_and_polish.md
+++ b/docs/phases/phase08_error_security_and_polish.md
@@ -17,3 +17,12 @@ The app operates safely in production environments with robust error handling an
 
 ## Dependencies
 Completion of all prior phases.
+
+## Status
+In Progress – current sprint focuses on signing and release preparation.
+
+## Sprint Plan
+- [x] Sanitize all input and hide sensitive data
+- [x] Integrate security scanning in CI
+- [ ] Sign binaries for each platform
+- [ ] Document reproducible build steps


### PR DESCRIPTION
## Summary
- document current phase status in the roadmap
- add a dashboard file for sprint overview
- record completion and sprint plans in each phase document
- link roadmap and dashboard from the README

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go test -race ./...` *(fails: Forbidden)*
- `npm test --prefix frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861484604d0832aa99b4cde74084358