### PR TITLE
Improve startup logging

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,41 +1,51 @@
 package main
 
 import (
-        "log"
-        "path/filepath"
+	"log"
+	"path/filepath"
 
-        "cli-wrapper/internal/app"
-        "cli-wrapper/internal/history"
-        "cli-wrapper/internal/logging"
-        "cli-wrapper/internal/server"
+	"cli-wrapper/internal/app"
+	"cli-wrapper/internal/history"
+	"cli-wrapper/internal/logging"
+	"cli-wrapper/internal/server"
 )
 
 func main() {
-	base, err := app.PrepareDirectories()
+	base, err := app.AppDir()
 	if err != nil {
-		log.Fatal(err)
+		log.Printf("app dir: %v", err)
+		return
 	}
+	logger, err := logging.NewWithPath(filepath.Join(base, "logs", "logs.txt"))
+	if err != nil {
+		log.Printf("init logger: %v", err)
+		return
+	}
+	defer logger.Close()
+
+	if err := app.PrepareDirectories(); err != nil {
+		logger.Error("prepare dirs: " + err.Error())
+		return
+	}
+
 	cfg, err := app.LoadConfig(base)
 	if err != nil {
-		log.Fatal(err)
+		logger.Error("load config: " + err.Error())
+		return
 	}
-        logger, err := logging.NewWithPath(filepath.Join(base, "logs", "logs.txt"))
-        if err != nil {
-                log.Fatal(err)
-        }
-        defer logger.Close()
 
-        hist, err := history.New(base)
-        if err != nil {
-                log.Fatal(err)
-        }
-        defer hist.Close()
+	hist, err := history.New(base)
+	if err != nil {
+		logger.Error("history: " + err.Error())
+		return
+	}
+	defer hist.Close()
 
-        mgr := app.NewSessionManager(base, logger, cfg.Concurrency, &cfg, hist)
-        defer mgr.Close()
+	mgr := app.NewSessionManager(base, logger, cfg.Concurrency, &cfg, hist)
+	defer mgr.Close()
 
-        srv := server.New(mgr, logger, base, &cfg, hist)
+	srv := server.New(mgr, logger, base, &cfg, hist)
 	if err := srv.Start(":8080"); err != nil {
-		log.Fatal(err)
+		logger.Error(err.Error())
 	}
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"cli-wrapper/internal/app"
+)
+
+func TestServerStartupLogFailure(t *testing.T) {
+	home := t.TempDir()
+	os.Setenv("HOME", home)
+	defer os.Unsetenv("HOME")
+
+	base, err := app.AppDir()
+	if err != nil {
+		t.Fatalf("app dir: %v", err)
+	}
+	cfgDir := filepath.Join(base, "config")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mk config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte("bad"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	main()
+
+	logPath := filepath.Join(base, "logs", "logs.txt")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !strings.Contains(string(data), "load config") {
+		t.Fatalf("log missing: %s", string(data))
+	}
+}

--- a/cmd/wailsapp/main.go
+++ b/cmd/wailsapp/main.go
@@ -1,41 +1,50 @@
 package main
 
 import (
-        "log"
-        "path/filepath"
+	"log"
+	"path/filepath"
 
-        "github.com/wailsapp/wails/v2"
+	"github.com/wailsapp/wails/v2"
 
-        "cli-wrapper/internal/app"
-        "cli-wrapper/internal/history"
-        "cli-wrapper/internal/logging"
+	"cli-wrapper/internal/app"
+	"cli-wrapper/internal/history"
+	"cli-wrapper/internal/logging"
 )
 
 func main() {
-	base, err := app.PrepareDirectories()
+	base, err := app.AppDir()
 	if err != nil {
-		log.Fatal(err)
+		log.Printf("app dir: %v", err)
+		return
 	}
+	logger, err := logging.NewWithPath(filepath.Join(base, "logs", "logs.txt"))
+	if err != nil {
+		log.Printf("init logger: %v", err)
+		return
+	}
+	defer logger.Close()
+
+	if err := app.PrepareDirectories(); err != nil {
+		logger.Error("prepare dirs: " + err.Error())
+		return
+	}
+
 	cfg, err := app.LoadConfig(base)
 	if err != nil {
-		log.Fatal(err)
+		logger.Error("load config: " + err.Error())
+		return
 	}
-        logger, err := logging.NewWithPath(filepath.Join(base, "logs", "logs.txt"))
-        if err != nil {
-                log.Fatal(err)
-        }
-        defer logger.Close()
-        hist, err := history.New(base)
-        if err != nil {
-                log.Fatal(err)
-        }
-        defer hist.Close()
-
-        mgr := app.NewSessionManager(base, logger, cfg.Concurrency, &cfg, hist)
-        defer mgr.Close()
-        backend := app.NewBackend(mgr, logger, &cfg)
-	err = wails.Run(&wails.Options{Bind: []interface{}{backend}, OnStartup: backend.Startup})
+	hist, err := history.New(base)
 	if err != nil {
-		log.Fatal(err)
+		logger.Error("history: " + err.Error())
+		return
+	}
+	defer hist.Close()
+
+	mgr := app.NewSessionManager(base, logger, cfg.Concurrency, &cfg, hist)
+	defer mgr.Close()
+	backend := app.NewBackend(mgr, logger, &cfg)
+	if err := wails.Run(&wails.Options{Bind: []interface{}{backend}, OnStartup: backend.Startup}); err != nil {
+		logger.Error(err.Error())
 	}
 }

--- a/cmd/wailsapp/main_test.go
+++ b/cmd/wailsapp/main_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"cli-wrapper/internal/app"
+)
+
+func TestAppStartupLogFailure(t *testing.T) {
+	home := t.TempDir()
+	os.Setenv("HOME", home)
+	defer os.Unsetenv("HOME")
+
+	base, err := app.AppDir()
+	if err != nil {
+		t.Fatalf("app dir: %v", err)
+	}
+	cfgDir := filepath.Join(base, "config")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mk config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte("bad"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	main()
+
+	logPath := filepath.Join(base, "logs", "logs.txt")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !strings.Contains(string(data), "load config") {
+		t.Fatalf("log missing: %s", string(data))
+	}
+}


### PR DESCRIPTION
## Summary
- switch `cmd/server` and `cmd/wailsapp` to use structured logger on startup
- initialise logger before config/history loading so errors are captured
- gracefully exit instead of `log.Fatal`
- add unit tests confirming startup failures are logged

## Testing
- `go vet ./...` *(fails: access to storage.googleapis.com blocked)*
- `go test -race ./...` *(fails: access to storage.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6861c5666cf4832a997141d32e600fa0