### PR TITLE
Add config settings for concurrency and working directory

### DIFF
--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -8,7 +8,8 @@ import (
 
 func TestConfigLoadSave(t *testing.T) {
 	dir := t.TempDir()
-	cfg := Config{Concurrency: 3, Theme: "dark", CPUThreshold: 50, MemoryThreshold: 50, PollInterval: 2}
+	wd := t.TempDir()
+	cfg := Config{Concurrency: 3, Theme: "dark", CPUThreshold: 50, MemoryThreshold: 50, PollInterval: 2, WorkingDir: wd}
 	if err := SaveConfig(dir, cfg); err != nil {
 		t.Fatalf("save config: %v", err)
 	}
@@ -22,8 +23,8 @@ func TestConfigLoadSave(t *testing.T) {
 	if loaded.Theme != "dark" {
 		t.Fatalf("got %s want dark", loaded.Theme)
 	}
-	if loaded.CPUThreshold != 50 || loaded.MemoryThreshold != 50 {
-		t.Fatalf("thresholds not saved")
+	if loaded.CPUThreshold != 50 || loaded.MemoryThreshold != 50 || loaded.WorkingDir != wd {
+		t.Fatalf("config not saved")
 	}
 	// corrupt file should default to 1
 	path := filepath.Join(dir, "config", "config.json")
@@ -54,5 +55,10 @@ func TestConfigLoadSave(t *testing.T) {
 	cfg.PollInterval = 0
 	if err := SaveConfig(dir, cfg); err == nil {
 		t.Fatal("expected error for invalid poll interval")
+	}
+	cfg.PollInterval = 2
+	cfg.WorkingDir = filepath.Join(dir, "missing")
+	if err := SaveConfig(dir, cfg); err == nil {
+		t.Fatal("expected error for invalid working dir")
 	}
 }

--- a/internal/app/session_manager.go
+++ b/internal/app/session_manager.go
@@ -96,6 +96,7 @@ func (m *SessionManager) dispatch() {
 func (m *SessionManager) run(req sessionRequest) {
 	ctx, cancel := context.WithCancel(m.ctx)
 	cmd := exec.CommandContext(ctx, req.model, req.args...)
+	cmd.Dir = m.cfg.WorkingDir
 	var buf bytes.Buffer
 	cmd.Stdout = &buf
 	cmd.Stderr = &buf

--- a/internal/app/session_manager_test.go
+++ b/internal/app/session_manager_test.go
@@ -1,29 +1,31 @@
 package app
 
 import (
-        "path/filepath"
-        "testing"
-        "time"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
 
-        "cli-wrapper/internal/history"
-        "cli-wrapper/internal/logging"
+	"cli-wrapper/internal/history"
+	"cli-wrapper/internal/logging"
 )
 
 func TestSessionManagerQueue(t *testing.T) {
 	logger, _ := logging.NewWithPath(filepath.Join(t.TempDir(), "log.txt"))
 	defer logger.Close()
-        cfg := &Config{Concurrency: 1, CPUThreshold: 50, MemoryThreshold: 50, PollInterval: 1}
-        hist, _ := history.New(t.TempDir())
-        defer hist.Close()
-        m := NewSessionManager(t.TempDir(), logger, 1, cfg, hist)
+	cfg := &Config{Concurrency: 1, CPUThreshold: 50, MemoryThreshold: 50, PollInterval: 1}
+	hist, _ := history.New(t.TempDir())
+	defer hist.Close()
+	m := NewSessionManager(t.TempDir(), logger, 1, cfg, hist)
 	defer m.Close()
 
 	start := time.Now()
-        id1, err := m.AddSession("sh", "", []string{"-c", "sleep 0.1"})
+	id1, err := m.AddSession("sh", "", []string{"-c", "sleep 0.1"})
 	if err != nil {
 		t.Fatalf("add1: %v", err)
 	}
-        id2, err := m.AddSession("sh", "", []string{"-c", "sleep 0.1"})
+	id2, err := m.AddSession("sh", "", []string{"-c", "sleep 0.1"})
 	if err != nil {
 		t.Fatalf("add2: %v", err)
 	}
@@ -41,18 +43,46 @@ func TestSessionManagerQueue(t *testing.T) {
 func TestSessionTerminate(t *testing.T) {
 	logger, _ := logging.NewWithPath(filepath.Join(t.TempDir(), "log.txt"))
 	defer logger.Close()
-        cfg := &Config{Concurrency: 1, CPUThreshold: 50, MemoryThreshold: 50, PollInterval: 1}
-        hist, _ := history.New(t.TempDir())
-        defer hist.Close()
-        m := NewSessionManager(t.TempDir(), logger, 1, cfg, hist)
+	cfg := &Config{Concurrency: 1, CPUThreshold: 50, MemoryThreshold: 50, PollInterval: 1}
+	hist, _ := history.New(t.TempDir())
+	defer hist.Close()
+	m := NewSessionManager(t.TempDir(), logger, 1, cfg, hist)
 	defer m.Close()
 
-        id, err := m.AddSession("sh", "", []string{"-c", "sleep 2"})
+	id, err := m.AddSession("sh", "", []string{"-c", "sleep 2"})
 	if err != nil {
 		t.Fatalf("add: %v", err)
 	}
 	time.Sleep(50 * time.Millisecond)
 	if err := m.Terminate(id); err != nil {
 		t.Fatalf("terminate: %v", err)
+	}
+}
+
+func TestSessionWorkingDir(t *testing.T) {
+	logger, _ := logging.NewWithPath(filepath.Join(t.TempDir(), "log.txt"))
+	defer logger.Close()
+	work := t.TempDir()
+	cfg := &Config{Concurrency: 1, CPUThreshold: 50, MemoryThreshold: 50, PollInterval: 1, WorkingDir: work}
+	hist, _ := history.New(t.TempDir())
+	defer hist.Close()
+	m := NewSessionManager(t.TempDir(), logger, 1, cfg, hist)
+	defer m.Close()
+
+	outFile := filepath.Join(t.TempDir(), "out.txt")
+	cmd := "pwd > " + outFile
+	if _, err := m.AddSession("sh", "", []string{"-c", cmd}); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	for len(m.Sessions()) > 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("read out: %v", err)
+	}
+	got := string(bytes.TrimSpace(data))
+	if got != work {
+		t.Fatalf("got %s want %s", got, work)
 	}
 }


### PR DESCRIPTION
## Summary
- extend config struct with WorkingDir and defaults
- add `/config` endpoint to read and store concurrency & working directory
- ensure `SessionManager` runs commands in configured directory
- implement settings dialog in React UI
- test configuration persistence, validation, and new server route

## Testing
- `go vet ./...` *(fails: modernc.org/sqlite download blocked)*
- `go test -race ./...` *(fails: modernc.org/sqlite download blocked)*
- `npm test --prefix frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68621e4d0a70832a8b97e0abd53b87b4