### PR TITLE
Update docs with consistent sentinel.log path

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ Resource throttling parameters are also configurable via `config.json`:
 ```
 If a running session exceeds these CPU or memory limits it is first throttled by
 reducing process priority. Persistent overages cause the session to be
-terminated. All alerts are recorded in `logs.txt`.
+terminated. All alerts are recorded in `sentinel.log` within `/var/log` on
+Unix or `C:\\Temp` on Windows.
 
 ## Model Switch Alerts
 

--- a/docs/phases/phase01_core_app_foundation.md
+++ b/docs/phases/phase01_core_app_foundation.md
@@ -13,7 +13,8 @@ Establish the base Wails application with cross-platform configuration and initi
   - Linux: `~/.config/ai-cli-ui/`
 - Detect whether the `openai` or `gemini` CLI is available in the system path.
 - Implement the initial UI with a prompt input, an output pane, and a model selector.
-- Log each CLI invocation to `logs.txt` in the app directory.
+- Log each CLI invocation to `sentinel.log` in the external log directory
+  (e.g., `/var/log` or `C:\\Temp`).
 - Add `toolchain go1.24.x` to `go.mod` for consistent builds across environments.
 - Document cross-platform build commands such as `wails build -platform windows/amd64`.
 

--- a/docs/phases/phase04_model_change_alerts_and_logging.md
+++ b/docs/phases/phase04_model_change_alerts_and_logging.md
@@ -6,7 +6,9 @@ Track model selections per session and make changes visible through the UI and l
 ## Detailed Steps
 - Persist the last-used model for each session.
 - When a model switch occurs, highlight the UI with a message like “⚠️ Model switched from gpt-4 to gemini-1.5-pro.”
-- Append the change event, CLI command, prompt, and timestamp to `logs.txt`.
+- Append the change event, CLI command, prompt, and timestamp to
+  `sentinel.log` in the external log directory (e.g., `/var/log` or
+  `C:\\Temp`).
 - Ensure all logged timestamps use UTC.
 - Emit a runtime event to display alerts using the Wails event bus.
 - Write logs in JSON Lines format and rotate files when they exceed 20 MB.

--- a/docs/phases/phase05_resource_throttling_and_telemetry.md
+++ b/docs/phases/phase05_resource_throttling_and_telemetry.md
@@ -7,7 +7,8 @@ Monitor system usage and prevent the application from consuming excessive resour
 - Use the `gopsutil` library to read process memory and CPU statistics.
 - Alert the user if consumption exceeds 35% of system memory or CPU.
 - If high usage persists, automatically throttle or cancel the affected session.
-- Record resource alerts and throttling actions in `logs.txt`.
+- Record resource alerts and throttling actions in `sentinel.log` located
+  in the external log directory (e.g., `/var/log` or `C:\\Temp`).
 - Poll resource metrics every two seconds to remain lightweight.
 - Throttle by reducing process priority with platform-specific system calls.
 - Allow thresholds and polling interval to be configured in `config.json`.

--- a/docs/phases/phase08_error_security_and_polish.md
+++ b/docs/phases/phase08_error_security_and_polish.md
@@ -6,7 +6,8 @@ Harden the application against common security issues and finalize UX details.
 ## Detailed Steps
 - Sanitize all user input before invoking CLI commands to prevent injection.
 - Mask API keys or sensitive values if they are ever displayed in the UI.
-- Catch and handle all Go subprocess errors, logging failures to `logs.txt`.
+- Catch and handle all Go subprocess errors, logging failures to `sentinel.log`
+  under the external log directory (e.g., `/var/log` or `C:\\Temp`).
 - Write comprehensive logs for every error scenario, ensuring no user data leaks.
 - Sign application binaries for Windows, macOS, and Linux distributions.
 - Run static analysis tools like `gosec` and `npm audit` during CI.


### PR DESCRIPTION
## Summary
- document sentinel.log usage for CLI invocation logging
- update model switch alert docs to use sentinel.log
- clarify resource throttling and error logging docs
- standardize log path reference in README

## Testing
- `go vet ./...` *(fails: Forbidden access to modules)*
- `go test -race ./...` *(fails: Forbidden access to modules)*
- `npm test --prefix frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862320983dc832aa2cc3b5cfc20e0be