### PR TITLE
Add CI runner script

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ go test -race ./...
 npm test --prefix frontend
 ```
 
+You can also run `scripts/run_ci.sh` to execute `go vet`, `go test`, and `go build` with output logged to the sentinel log.
+
 ## Wails Application
 
 The repository also contains a minimal Wails v2 application located in the

--- a/cmd/runci/main.go
+++ b/cmd/runci/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"log"
+	"os"
+	"os/exec"
+
+	"cli-wrapper/internal/logging"
+)
+
+func run(logger *logging.Logger, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	out, err := cmd.CombinedOutput()
+	buf := bytes.TrimSpace(out)
+	if len(buf) > 0 {
+		scanner := bufio.NewScanner(bytes.NewReader(buf))
+		for scanner.Scan() {
+			logger.Info(name + ": " + scanner.Text())
+		}
+	}
+	if err != nil {
+		logger.Error(name + " failed: " + err.Error())
+	} else {
+		logger.Info(name + " succeeded")
+	}
+	return err
+}
+
+func main() {
+	logger, err := logging.New()
+	if err != nil {
+		log.Fatalf("init logger: %v", err)
+	}
+	defer logger.Close()
+
+	if err := run(logger, "go", "vet", "./..."); err != nil {
+		os.Exit(1)
+	}
+	if err := run(logger, "go", "test", "./..."); err != nil {
+		os.Exit(1)
+	}
+	if err := run(logger, "go", "build", "./..."); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/runci/main_test.go
+++ b/cmd/runci/main_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"cli-wrapper/internal/logging"
+)
+
+func TestRunSuccess(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "log.txt")
+	logger, err := logging.NewWithPath(logPath)
+	if err != nil {
+		t.Fatalf("new logger: %v", err)
+	}
+	defer logger.Close()
+
+	if err := run(logger, "go", "version"); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !bytes.Contains(data, []byte("go:")) {
+		t.Fatalf("missing log output: %s", data)
+	}
+}
+
+func TestRunFailure(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "log.txt")
+	logger, err := logging.NewWithPath(logPath)
+	if err != nil {
+		t.Fatalf("new logger: %v", err)
+	}
+	defer logger.Close()
+
+	if err := run(logger, "go", "unknowncmd"); err == nil {
+		t.Fatalf("expected error")
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !bytes.Contains(data, []byte("failed")) {
+		t.Fatalf("missing failure log: %s", data)
+	}
+}

--- a/scripts/run_ci.sh
+++ b/scripts/run_ci.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Navigate to repo root
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Build and run the CI helper written in Go
+GO_RUN="go run ./cmd/runci"
+
+$GO_RUN


### PR DESCRIPTION
## Summary
- add new `run_ci.sh` script to run vet/test/build
- implement `runci` helper for logging command output
- mention the CI script in README

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6862330120a8832a83c831a00d8504c6