### PR TITLE
Fix build errors in server and Wails app

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,9 +10,9 @@ import (
 )
 
 func main() {
-	base, err := app.AppDir()
+	base, err := app.PrepareDirectories()
 	if err != nil {
-		log.Printf("app dir: %v", err)
+		log.Printf("prepare dirs: %v", err)
 		return
 	}
 	logger, err := logging.New()
@@ -21,11 +21,6 @@ func main() {
 		return
 	}
 	defer logger.Close()
-
-	if err := app.PrepareDirectories(); err != nil {
-		logger.Error("prepare dirs: " + err.Error())
-		return
-	}
 
 	cfg, err := app.LoadConfig(base)
 	if err != nil {

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -15,9 +15,9 @@ func TestServerStartupLogFailure(t *testing.T) {
 	os.Setenv("HOME", home)
 	defer os.Unsetenv("HOME")
 
-	base, err := app.AppDir()
+	base, err := app.PrepareDirectories()
 	if err != nil {
-		t.Fatalf("app dir: %v", err)
+		t.Fatalf("prep dirs: %v", err)
 	}
 	cfgDir := filepath.Join(base, "config")
 	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
@@ -33,10 +33,6 @@ func TestServerStartupLogFailure(t *testing.T) {
 		t.Fatalf("new logger: %v", err)
 	}
 	defer logger.Close()
-
-	if err := app.PrepareDirectories(); err != nil {
-		t.Fatalf("prep dirs: %v", err)
-	}
 
 	_, err = app.LoadConfig(base)
 	if err != nil {

--- a/cmd/wailsapp/main.go
+++ b/cmd/wailsapp/main.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/wailsapp/wails/v2"
+	"github.com/wailsapp/wails/v2/pkg/options"
 
 	"cli-wrapper/internal/app"
 	"cli-wrapper/internal/history"
@@ -12,9 +13,9 @@ import (
 )
 
 func main() {
-	base, err := app.AppDir()
+	base, err := app.PrepareDirectories()
 	if err != nil {
-		log.Printf("app dir: %v", err)
+		log.Printf("prepare dirs: %v", err)
 		return
 	}
 	logger, err := logging.NewWithPath(filepath.Join(base, "logs", "logs.txt"))
@@ -23,11 +24,6 @@ func main() {
 		return
 	}
 	defer logger.Close()
-
-	if err := app.PrepareDirectories(); err != nil {
-		logger.Error("prepare dirs: " + err.Error())
-		return
-	}
 
 	cfg, err := app.LoadConfig(base)
 	if err != nil {
@@ -44,7 +40,8 @@ func main() {
 	mgr := app.NewSessionManager(base, logger, cfg.Concurrency, &cfg, hist)
 	defer mgr.Close()
 	backend := app.NewBackend(mgr, logger, &cfg)
-	if err := wails.Run(&wails.Options{Bind: []interface{}{backend}, OnStartup: backend.Startup}); err != nil {
+	opts := &options.App{Bind: []interface{}{backend}, OnStartup: backend.Startup}
+	if err := wails.Run(opts); err != nil {
 		logger.Error(err.Error())
 	}
 }


### PR DESCRIPTION
## Summary
- correct usage of `PrepareDirectories` in server and Wails app mains
- use `options.App` for Wails launch
- update tests to match new signature

## Testing
- `go vet ./...`
- `go test ./...` *(fails: TestSessionManagerQueue, TestStoreCRUD, TestEndpoints)*

------
https://chatgpt.com/codex/tasks/task_e_6862339dbe28832a8cec4c3610fa4294