### PR TITLE
Implement CLI plugin architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,8 @@ The Wails backend tracks the last-used model. When a new prompt specifies a diff
 model, the backend emits a `model:switched` event via the Wails event bus and logs the
 change in JSON Lines format. Log files automatically rotate after reaching 20 MB.
 
+
+## CLI Plugins
+
+The application supports extensible CLI integrations via a plugin mechanism. Each plugin must implement the `plugins.Plugin` interface and register itself during initialization using `plugins.Register`. Registered plugins are automatically detected at runtime. See `internal/plugins/openai.go` and `internal/plugins/gemini.go` for reference implementations.
+

--- a/internal/app/billing.go
+++ b/internal/app/billing.go
@@ -1,55 +1,30 @@
 package app
 
 import (
-	"encoding/json"
 	"fmt"
-	"os/exec"
+
+	"cli-wrapper/internal/plugins"
 )
 
 // BillingUsage holds credit usage information returned by the CLI.
-type BillingUsage struct {
-	TotalGranted   float64 `json:"total_granted"`
-	TotalUsed      float64 `json:"total_used"`
-	TotalAvailable float64 `json:"total_available"`
-}
+// BillingUsage is an alias for plugins.BillingUsage for backward compatibility.
+type BillingUsage = plugins.BillingUsage
 
 // BillingURL returns the billing page URL for the given CLI tool.
 func BillingURL(tool string) (string, error) {
-	switch tool {
-	case "openai":
-		return "https://platform.openai.com/account/billing", nil
-	case "gemini":
-		return "https://makersuite.google.com/app/apikey", nil
-	default:
+	p, ok := plugins.Get(tool)
+	if !ok {
 		return "", fmt.Errorf("unknown tool %q", tool)
 	}
+	return p.BillingURL(), nil
 }
 
 // FetchUsage executes the CLI to retrieve usage information if supported.
 // It returns an error if the CLI does not provide usage details.
 func FetchUsage(tool string) (*BillingUsage, error) {
-	switch tool {
-	case "openai":
-		out, err := exec.Command("openai", "api", "request", "GET", "/dashboard/billing/credit_grants").Output()
-		if err != nil {
-			return nil, fmt.Errorf("openai usage: %w", err)
-		}
-		var res BillingUsage
-		if err := json.Unmarshal(out, &res); err != nil {
-			return nil, fmt.Errorf("parse openai usage: %w", err)
-		}
-		return &res, nil
-	case "gemini":
-		out, err := exec.Command("gemini", "usage").Output()
-		if err != nil {
-			return nil, fmt.Errorf("gemini usage: %w", err)
-		}
-		var res BillingUsage
-		if err := json.Unmarshal(out, &res); err != nil {
-			return nil, fmt.Errorf("parse gemini usage: %w", err)
-		}
-		return &res, nil
-	default:
+	p, ok := plugins.Get(tool)
+	if !ok {
 		return nil, fmt.Errorf("unsupported tool %q", tool)
 	}
+	return p.Usage()
 }

--- a/internal/plugins/gemini.go
+++ b/internal/plugins/gemini.go
@@ -1,0 +1,44 @@
+package plugins
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+)
+
+type geminiPlugin struct{}
+
+func (geminiPlugin) Name() string { return "gemini" }
+
+func (geminiPlugin) Detect() bool {
+	_, err := exec.LookPath("gemini")
+	return err == nil
+}
+
+func (geminiPlugin) Invoke(args []string) error {
+	cmd := exec.Command("gemini", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gemini: %w", err)
+	}
+	fmt.Print(string(out))
+	return nil
+}
+
+func (geminiPlugin) BillingURL() string {
+	return "https://makersuite.google.com/app/apikey"
+}
+
+func (geminiPlugin) Usage() (*BillingUsage, error) {
+	out, err := exec.Command("gemini", "usage").Output()
+	if err != nil {
+		return nil, fmt.Errorf("gemini usage: %w", err)
+	}
+	var u BillingUsage
+	if err := json.Unmarshal(out, &u); err != nil {
+		return nil, fmt.Errorf("parse usage: %w", err)
+	}
+	return &u, nil
+}
+
+func init() { Register(geminiPlugin{}) }

--- a/internal/plugins/openai.go
+++ b/internal/plugins/openai.go
@@ -1,0 +1,44 @@
+package plugins
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+)
+
+type openAIPlugin struct{}
+
+func (openAIPlugin) Name() string { return "openai" }
+
+func (openAIPlugin) Detect() bool {
+	_, err := exec.LookPath("openai")
+	return err == nil
+}
+
+func (openAIPlugin) Invoke(args []string) error {
+	cmd := exec.Command("openai", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("openai: %w", err)
+	}
+	fmt.Print(string(out))
+	return nil
+}
+
+func (openAIPlugin) BillingURL() string {
+	return "https://platform.openai.com/account/billing"
+}
+
+func (openAIPlugin) Usage() (*BillingUsage, error) {
+	out, err := exec.Command("openai", "api", "request", "GET", "/dashboard/billing/credit_grants").Output()
+	if err != nil {
+		return nil, fmt.Errorf("openai usage: %w", err)
+	}
+	var u BillingUsage
+	if err := json.Unmarshal(out, &u); err != nil {
+		return nil, fmt.Errorf("parse usage: %w", err)
+	}
+	return &u, nil
+}
+
+func init() { Register(openAIPlugin{}) }

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -1,0 +1,58 @@
+package plugins
+
+import (
+	"sort"
+	"sync"
+)
+
+// BillingUsage holds credit usage information returned by a CLI.
+type BillingUsage struct {
+	TotalGranted   float64 `json:"total_granted"`
+	TotalUsed      float64 `json:"total_used"`
+	TotalAvailable float64 `json:"total_available"`
+}
+
+// Plugin defines the interface all CLI plugins must implement.
+type Plugin interface {
+	Name() string
+	Detect() bool
+	Invoke(args []string) error
+	BillingURL() string
+	Usage() (*BillingUsage, error)
+}
+
+var (
+	mu       sync.RWMutex
+	registry = make(map[string]Plugin)
+)
+
+// Register adds a plugin to the registry.
+func Register(p Plugin) {
+	mu.Lock()
+	defer mu.Unlock()
+	registry[p.Name()] = p
+}
+
+// Get retrieves a plugin by name.
+func Get(name string) (Plugin, bool) {
+	mu.RLock()
+	defer mu.RUnlock()
+	p, ok := registry[name]
+	return p, ok
+}
+
+// All returns all registered plugins sorted by name.
+func All() []Plugin {
+	mu.RLock()
+	defer mu.RUnlock()
+	names := make([]string, 0, len(registry))
+	for n := range registry {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	res := make([]Plugin, 0, len(names))
+	for _, n := range names {
+		res = append(res, registry[n])
+	}
+	return res
+}


### PR DESCRIPTION
## Summary
- add new plugin framework with registry and default plugins for OpenAI and Gemini
- switch CLI helpers and billing helpers to use plugins
- document plugin registration in README

## Testing
- `go vet ./...`
- `go test ./...` *(fails: TestSessionManagerQueue and TestStoreCRUD)*

------
https://chatgpt.com/codex/tasks/task_e_68623608421c832aa3c2e8f5d6b93214