### PR TITLE
Add configurable log level and path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ go build ./cmd/phasefirst
 ```
 
 The command writes operational logs to `sentinel.log` in `/var/log` on Unix or
-`C:\Temp` on Windows. Logs are stored in JSON with automatic rotation.
+`C:\Temp` on Windows. Logs are stored in JSON with automatic rotation. Both the
+log file path and verbosity level are configurable via `config.json`.
 
 ### Testing
 
@@ -80,7 +81,9 @@ Resource throttling parameters are also configurable via `config.json`:
 {
   "cpuThreshold": 35,
   "memoryThreshold": 35,
-  "pollInterval": 2
+  "pollInterval": 2,
+  "logLevel": "info",
+  "logPath": "<path>"
 }
 ```
 If a running session exceeds these CPU or memory limits it is first throttled by

--- a/cmd/phasefirst/main.go
+++ b/cmd/phasefirst/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	logger, err := logging.New()
+	logger, err := logging.New("info", "")
 	if err != nil {
 		log.Fatalf("failed to init logger: %v", err)
 	}

--- a/cmd/runci/main.go
+++ b/cmd/runci/main.go
@@ -29,7 +29,7 @@ func run(logger *logging.Logger, name string, args ...string) error {
 }
 
 func main() {
-	logger, err := logging.New()
+	logger, err := logging.New("info", "")
 	if err != nil {
 		log.Fatalf("init logger: %v", err)
 	}

--- a/cmd/runci/main_test.go
+++ b/cmd/runci/main_test.go
@@ -12,7 +12,7 @@ import (
 func TestRunSuccess(t *testing.T) {
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, "log.txt")
-	logger, err := logging.NewWithPath(logPath)
+	logger, err := logging.NewWithPath("info", logPath)
 	if err != nil {
 		t.Fatalf("new logger: %v", err)
 	}
@@ -33,7 +33,7 @@ func TestRunSuccess(t *testing.T) {
 func TestRunFailure(t *testing.T) {
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, "log.txt")
-	logger, err := logging.NewWithPath(logPath)
+	logger, err := logging.NewWithPath("info", logPath)
 	if err != nil {
 		t.Fatalf("new logger: %v", err)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"path/filepath"
 
 	"cli-wrapper/internal/app"
 	"cli-wrapper/internal/history"
@@ -15,17 +16,21 @@ func main() {
 		log.Printf("prepare dirs: %v", err)
 		return
 	}
-	logger, err := logging.New()
+	cfg, cfgErr := app.LoadConfig(base)
+	if cfg.LogLevel == "" {
+		cfg.LogLevel = "info"
+	}
+	if cfg.LogPath == "" {
+		cfg.LogPath = filepath.Join(base, "logs", "logs.txt")
+	}
+	logger, err := logging.New(cfg.LogLevel, cfg.LogPath)
 	if err != nil {
 		log.Printf("init logger: %v", err)
 		return
 	}
 	defer logger.Close()
-
-	cfg, err := app.LoadConfig(base)
-	if err != nil {
-		logger.Error("load config: " + err.Error())
-		return
+	if cfgErr != nil {
+		logger.Error("load config: " + cfgErr.Error())
 	}
 
 	hist, err := history.New(base)

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -28,7 +28,7 @@ func TestServerStartupLogFailure(t *testing.T) {
 	}
 
 	logPath := filepath.Join(t.TempDir(), "log.txt")
-	logger, err := logging.NewWithPath(logPath)
+	logger, err := logging.NewWithPath("info", logPath)
 	if err != nil {
 		t.Fatalf("new logger: %v", err)
 	}

--- a/cmd/wailsapp/main.go
+++ b/cmd/wailsapp/main.go
@@ -18,17 +18,21 @@ func main() {
 		log.Printf("prepare dirs: %v", err)
 		return
 	}
-	logger, err := logging.NewWithPath(filepath.Join(base, "logs", "logs.txt"))
+	cfg, cfgErr := app.LoadConfig(base)
+	if cfg.LogLevel == "" {
+		cfg.LogLevel = "info"
+	}
+	if cfg.LogPath == "" {
+		cfg.LogPath = filepath.Join(base, "logs", "logs.txt")
+	}
+	logger, err := logging.New(cfg.LogLevel, cfg.LogPath)
 	if err != nil {
 		log.Printf("init logger: %v", err)
 		return
 	}
 	defer logger.Close()
-
-	cfg, err := app.LoadConfig(base)
-	if err != nil {
-		logger.Error("load config: " + err.Error())
-		return
+	if cfgErr != nil {
+		logger.Error("load config: " + cfgErr.Error())
 	}
 	hist, err := history.New(base)
 	if err != nil {

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -33,7 +33,7 @@ func DetectCLITools() ([]string, error) {
 
 // InvokeTool runs the given CLI with args and logs the invocation.
 func InvokeTool(tool string, args []string, baseDir string) error {
-	logger, err := logging.New()
+	logger, err := logging.New("info", "")
 	if err != nil {
 		return err
 	}

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -9,7 +9,7 @@ import (
 func TestConfigLoadSave(t *testing.T) {
 	dir := t.TempDir()
 	wd := t.TempDir()
-	cfg := Config{Concurrency: 3, Theme: "dark", CPUThreshold: 50, MemoryThreshold: 50, PollInterval: 2, WorkingDir: wd}
+	cfg := Config{Concurrency: 3, Theme: "dark", CPUThreshold: 50, MemoryThreshold: 50, PollInterval: 2, WorkingDir: wd, LogLevel: "debug", LogPath: filepath.Join(dir, "log.txt")}
 	if err := SaveConfig(dir, cfg); err != nil {
 		t.Fatalf("save config: %v", err)
 	}
@@ -23,7 +23,7 @@ func TestConfigLoadSave(t *testing.T) {
 	if loaded.Theme != "dark" {
 		t.Fatalf("got %s want dark", loaded.Theme)
 	}
-	if loaded.CPUThreshold != 50 || loaded.MemoryThreshold != 50 || loaded.WorkingDir != wd {
+	if loaded.CPUThreshold != 50 || loaded.MemoryThreshold != 50 || loaded.WorkingDir != wd || loaded.LogLevel != "debug" || loaded.LogPath == "" {
 		t.Fatalf("config not saved")
 	}
 	// corrupt file should default to 1
@@ -60,5 +60,16 @@ func TestConfigLoadSave(t *testing.T) {
 	cfg.WorkingDir = filepath.Join(dir, "missing")
 	if err := SaveConfig(dir, cfg); err == nil {
 		t.Fatal("expected error for invalid working dir")
+	}
+
+	cfg.WorkingDir = wd
+	cfg.LogLevel = "unknown"
+	if err := SaveConfig(dir, cfg); err == nil {
+		t.Fatal("expected error for invalid log level")
+	}
+	cfg.LogLevel = "info"
+	cfg.LogPath = ""
+	if err := SaveConfig(dir, cfg); err == nil {
+		t.Fatal("expected error for empty log path")
 	}
 }

--- a/internal/history/store.go
+++ b/internal/history/store.go
@@ -1,43 +1,47 @@
 package history
 
 import (
-    "database/sql"
-    "encoding/json"
-    "fmt"
-    "path/filepath"
-    "time"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
 
-    _ "modernc.org/sqlite"
+	_ "modernc.org/sqlite"
 )
 
 type Record struct {
-    ID        string `json:"id"`
-    Prompt    string `json:"prompt"`
-    Response  string `json:"response"`
-    Model     string `json:"model"`
-    Timestamp string `json:"timestamp"`
-    Success   bool   `json:"success"`
+	ID        string `json:"id"`
+	Prompt    string `json:"prompt"`
+	Response  string `json:"response"`
+	Model     string `json:"model"`
+	Timestamp string `json:"timestamp"`
+	Success   bool   `json:"success"`
 }
 
 type Store struct {
-    db *sql.DB
+	db *sql.DB
 }
 
 func New(baseDir string) (*Store, error) {
-    path := filepath.Join(baseDir, "state", "history.db")
-    db, err := sql.Open("sqlite", path+"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)")
-    if err != nil {
-        return nil, fmt.Errorf("open db: %w", err)
-    }
-    if err := initSchema(db); err != nil {
-        db.Close()
-        return nil, err
-    }
-    return &Store{db: db}, nil
+	path := filepath.Join(baseDir, "state", "history.db")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("create state dir: %w", err)
+	}
+	db, err := sql.Open("sqlite", path+"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)")
+	if err != nil {
+		return nil, fmt.Errorf("open db: %w", err)
+	}
+	if err := initSchema(db); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return &Store{db: db}, nil
 }
 
 func initSchema(db *sql.DB) error {
-    schema := `
+	schema := `
 CREATE TABLE IF NOT EXISTS history(
     id TEXT PRIMARY KEY,
     prompt TEXT NOT NULL,
@@ -57,116 +61,115 @@ CREATE TRIGGER IF NOT EXISTS history_au AFTER UPDATE ON history BEGIN
     INSERT INTO history_fts(history_fts,rowid,prompt,response) VALUES('delete',old.rowid,old.prompt,old.response);
     INSERT INTO history_fts(rowid,prompt,response) VALUES(new.rowid,new.prompt,new.response);
 END;`
-    if _, err := db.Exec(schema); err != nil {
-        return fmt.Errorf("init schema: %w", err)
-    }
-    return nil
+	if _, err := db.Exec(schema); err != nil {
+		return fmt.Errorf("init schema: %w", err)
+	}
+	return nil
 }
 
 func (s *Store) Close() error {
-    return s.db.Close()
+	return s.db.Close()
 }
 
 func boolToInt(b bool) int {
-    if b {
-        return 1
-    }
-    return 0
+	if b {
+		return 1
+	}
+	return 0
 }
 
 func intToBool(i int) bool {
-    return i != 0
+	return i != 0
 }
 
 func (s *Store) Add(r Record) error {
-    if r.ID == "" {
-        return fmt.Errorf("id required")
-    }
-    if r.Timestamp == "" {
-        r.Timestamp = time.Now().UTC().Format(time.RFC3339)
-    }
-    _, err := s.db.Exec(`INSERT INTO history(id,prompt,response,model,timestamp,success) VALUES(?,?,?,?,?,?)`,
-        r.ID, r.Prompt, r.Response, r.Model, r.Timestamp, boolToInt(r.Success))
-    if err != nil {
-        return fmt.Errorf("insert: %w", err)
-    }
-    return nil
+	if r.ID == "" {
+		return fmt.Errorf("id required")
+	}
+	if r.Timestamp == "" {
+		r.Timestamp = time.Now().UTC().Format(time.RFC3339)
+	}
+	_, err := s.db.Exec(`INSERT INTO history(id,prompt,response,model,timestamp,success) VALUES(?,?,?,?,?,?)`,
+		r.ID, r.Prompt, r.Response, r.Model, r.Timestamp, boolToInt(r.Success))
+	if err != nil {
+		return fmt.Errorf("insert: %w", err)
+	}
+	return nil
 }
 
 func scanRows(rows *sql.Rows) ([]Record, error) {
-    var recs []Record
-    for rows.Next() {
-        var r Record
-        var success int
-        if err := rows.Scan(&r.ID, &r.Prompt, &r.Response, &r.Model, &r.Timestamp, &success); err != nil {
-            return nil, fmt.Errorf("scan: %w", err)
-        }
-        r.Success = intToBool(success)
-        recs = append(recs, r)
-    }
-    return recs, nil
+	var recs []Record
+	for rows.Next() {
+		var r Record
+		var success int
+		if err := rows.Scan(&r.ID, &r.Prompt, &r.Response, &r.Model, &r.Timestamp, &success); err != nil {
+			return nil, fmt.Errorf("scan: %w", err)
+		}
+		r.Success = intToBool(success)
+		recs = append(recs, r)
+	}
+	return recs, nil
 }
 
 func (s *Store) All() ([]Record, error) {
-    rows, err := s.db.Query(`SELECT id,prompt,response,model,timestamp,success FROM history ORDER BY timestamp DESC`)
-    if err != nil {
-        return nil, fmt.Errorf("query: %w", err)
-    }
-    defer rows.Close()
-    return scanRows(rows)
+	rows, err := s.db.Query(`SELECT id,prompt,response,model,timestamp,success FROM history ORDER BY timestamp DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("query: %w", err)
+	}
+	defer rows.Close()
+	return scanRows(rows)
 }
 
 func (s *Store) Search(q string, limit int) ([]Record, error) {
-    if limit <= 0 {
-        limit = 20
-    }
-    rows, err := s.db.Query(`SELECT id,prompt,response,model,timestamp,success FROM history WHERE rowid IN (SELECT rowid FROM history_fts WHERE history_fts MATCH ? LIMIT ?) ORDER BY timestamp DESC`, q, limit)
-    if err != nil {
-        return nil, fmt.Errorf("search: %w", err)
-    }
-    defer rows.Close()
-    return scanRows(rows)
+	if limit <= 0 {
+		limit = 20
+	}
+	rows, err := s.db.Query(`SELECT id,prompt,response,model,timestamp,success FROM history WHERE rowid IN (SELECT rowid FROM history_fts WHERE history_fts MATCH ? LIMIT ?) ORDER BY timestamp DESC`, q, limit)
+	if err != nil {
+		return nil, fmt.Errorf("search: %w", err)
+	}
+	defer rows.Close()
+	return scanRows(rows)
 }
 
 func (s *Store) Export() ([]byte, error) {
-    recs, err := s.All()
-    if err != nil {
-        return nil, err
-    }
-    data, err := json.MarshalIndent(recs, "", "  ")
-    if err != nil {
-        return nil, fmt.Errorf("marshal: %w", err)
-    }
-    return data, nil
+	recs, err := s.All()
+	if err != nil {
+		return nil, err
+	}
+	data, err := json.MarshalIndent(recs, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+	return data, nil
 }
 
 func (s *Store) Import(data []byte) error {
-    var recs []Record
-    if err := json.Unmarshal(data, &recs); err != nil {
-        return fmt.Errorf("unmarshal: %w", err)
-    }
-    tx, err := s.db.Begin()
-    if err != nil {
-        return fmt.Errorf("begin: %w", err)
-    }
-    stmt, err := tx.Prepare(`INSERT OR REPLACE INTO history(id,prompt,response,model,timestamp,success) VALUES(?,?,?,?,?,?)`)
-    if err != nil {
-        tx.Rollback()
-        return fmt.Errorf("prepare: %w", err)
-    }
-    defer stmt.Close()
-    for _, r := range recs {
-        if r.Timestamp == "" {
-            r.Timestamp = time.Now().UTC().Format(time.RFC3339)
-        }
-        if _, err := stmt.Exec(r.ID, r.Prompt, r.Response, r.Model, r.Timestamp, boolToInt(r.Success)); err != nil {
-            tx.Rollback()
-            return fmt.Errorf("exec: %w", err)
-        }
-    }
-    if err := tx.Commit(); err != nil {
-        return fmt.Errorf("commit: %w", err)
-    }
-    return nil
+	var recs []Record
+	if err := json.Unmarshal(data, &recs); err != nil {
+		return fmt.Errorf("unmarshal: %w", err)
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin: %w", err)
+	}
+	stmt, err := tx.Prepare(`INSERT OR REPLACE INTO history(id,prompt,response,model,timestamp,success) VALUES(?,?,?,?,?,?)`)
+	if err != nil {
+		tx.Rollback()
+		return fmt.Errorf("prepare: %w", err)
+	}
+	defer stmt.Close()
+	for _, r := range recs {
+		if r.Timestamp == "" {
+			r.Timestamp = time.Now().UTC().Format(time.RFC3339)
+		}
+		if _, err := stmt.Exec(r.ID, r.Prompt, r.Response, r.Model, r.Timestamp, boolToInt(r.Success)); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("exec: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	return nil
 }
-

--- a/internal/logging/logger_additional_test.go
+++ b/internal/logging/logger_additional_test.go
@@ -65,11 +65,14 @@ func TestRotateAndCleanup(t *testing.T) {
 func TestLoggerLevels(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sentinel.log")
-	logger, err := NewWithPath(path)
+	logger, err := NewWithPath("debug", path)
 	if err != nil {
 		t.Fatalf("new logger: %v", err)
 	}
 	defer logger.Close()
+	if err := logger.Debug("dbg"); err != nil {
+		t.Fatalf("debug: %v", err)
+	}
 	if err := logger.Info("hello"); err != nil {
 		t.Fatalf("info: %v", err)
 	}
@@ -84,8 +87,8 @@ func TestLoggerLevels(t *testing.T) {
 		t.Fatalf("read log: %v", err)
 	}
 	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
-	if len(lines) != 3 {
-		t.Fatalf("expected 3 lines got %d", len(lines))
+	if len(lines) != 4 {
+		t.Fatalf("expected 4 lines got %d", len(lines))
 	}
 	for _, l := range lines {
 		var obj map[string]any
@@ -101,14 +104,14 @@ func (errWriter) Write([]byte) (int, error) { return 0, fmt.Errorf("write fail")
 func (errWriter) Close() error              { return nil }
 
 func TestLogWriteError(t *testing.T) {
-	l := &Logger{writer: errWriter{}}
+	l := &Logger{writer: errWriter{}, level: LevelInfo}
 	if err := l.Info("bad"); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
 func TestModelSwitchWriteError(t *testing.T) {
-	l := &Logger{writer: errWriter{}}
+	l := &Logger{writer: errWriter{}, level: LevelInfo}
 	if err := l.ModelSwitch("a", "b", "p"); err == nil {
 		t.Fatal("expected error")
 	}
@@ -146,7 +149,7 @@ func TestRotateOpenError(t *testing.T) {
 func TestNewDefault(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sentinel.log")
-	l, err := NewWithPath(path)
+	l, err := NewWithPath("info", path)
 	if err != nil {
 		t.Fatalf("new: %v", err)
 	}

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -14,7 +14,7 @@ func TestLoggerWrite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newRotateWriter: %v", err)
 	}
-	logger := &Logger{writer: rw}
+	logger := &Logger{writer: rw, level: LevelDebug}
 	defer logger.Close()
 	if err := logger.Info("test"); err != nil {
 		t.Fatalf("info: %v", err)


### PR DESCRIPTION
## Summary
- add `LogLevel` and `LogPath` settings to config
- implement log level filtering and configurable path in logging
- load log settings in `server` and `wailsapp` cmds
- expose log settings via `/config` HTTP API
- document new configuration
- update tests for new fields and behaviours

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686238703ee0832ab265fc2000de4b29