### PR TITLE
Add cross-platform install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains helper utilities for the CLI Wrapper project.
 
 ## Installing prerequisites
 
-Run `scripts/install.sh` to automatically install Go 1.24+, Node.js 18+, and the Wails CLI for your platform.
+Run `scripts/install.sh` to install Go 1.24+, Node.js 18+, and the Wails CLI automatically for your platform.
 
 
 ## `phasefirst` Command

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,12 +6,15 @@ REQUIRED_GO=1.24
 REQUIRED_NODE=18
 
 # Detect operating system
-case "$(uname -s)" in
-    Linux*) OS="linux" ;;
-    Darwin*) OS="darwin" ;;
-    CYGWIN*|MINGW*|MSYS*) OS="windows" ;;
-    *) echo "Unsupported platform: $(uname -s)" >&2; exit 1 ;;
-esac
+if command -v cmd.exe >/dev/null 2>&1; then
+    OS="windows"
+else
+    case "$(uname -s)" in
+        Linux*) OS="linux" ;;
+        Darwin*) OS="darwin" ;;
+        *) echo "Unsupported platform: $(uname -s)" >&2; exit 1 ;;
+    esac
+fi
 ARCH=$(uname -m)
 
 version_ge() {


### PR DESCRIPTION
## Summary
- improve OS detection logic in `scripts/install.sh`
- tweak README to mention install script

## Testing
- `go vet ./...`
- `go test -race ./...`
- `npm test --prefix frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68623c7f810c832ab4d466be8e6c2382