### PR TITLE
Add cliwrap command

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,34 @@ append lines dynamically so results appear incrementally.
 ## CLI Plugins
 
 The application supports extensible CLI integrations via a plugin mechanism. Each plugin must implement the `plugins.Plugin` interface and register itself during initialization using `plugins.Register`. Registered plugins are automatically detected at runtime. See `internal/plugins/openai.go` and `internal/plugins/gemini.go` for reference implementations.
+
+## `cliwrap` Command
+
+The `cliwrap` tool provides a minimal terminal interface for running a model and managing history.
+
+### Examples
+
+Run a prompt and wait for the result:
+
+```bash
+cliwrap run -model sh -prompt "echo hello"
+```
+
+Export previous runs to a file:
+
+```bash
+cliwrap history export > history.json
+```
+
+Import history from standard input:
+
+```bash
+cat history.json | cliwrap history import
+```
+
+Global flags `-concurrency` and `-workdir` update the same `config.json` used by the desktop app:
+
+```bash
+cliwrap -concurrency 2 -workdir /tmp run -model sh -prompt "echo hi"
+```
+

--- a/cmd/cliwrap/main.go
+++ b/cmd/cliwrap/main.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	"cli-wrapper/internal/app"
+	"cli-wrapper/internal/history"
+	"cli-wrapper/internal/logging"
+)
+
+func usage() {
+	fmt.Fprintf(flag.CommandLine.Output(), `Usage:
+  cliwrap [flags] run -model MODEL -prompt PROMPT
+  cliwrap [flags] history export
+  cliwrap [flags] history import
+
+Flags:
+`)
+	flag.PrintDefaults()
+}
+
+func main() {
+	conc := flag.Int("concurrency", 0, "set concurrency and update config")
+	work := flag.String("workdir", "", "set working directory and update config")
+	flag.Usage = usage
+	flag.Parse()
+
+	base, err := app.PrepareDirectories()
+	if err != nil {
+		log.Fatalf("prepare dirs: %v", err)
+	}
+	cfg, cfgErr := app.LoadConfig(base)
+	if cfg.LogLevel == "" {
+		cfg.LogLevel = "info"
+	}
+	if cfg.LogPath == "" {
+		cfg.LogPath = filepath.Join(base, "logs", "logs.txt")
+	}
+
+	if *conc > 0 {
+		cfg.Concurrency = *conc
+	}
+	if *work != "" {
+		cfg.WorkingDir = *work
+	}
+	if *conc > 0 || *work != "" {
+		if err := app.SaveConfig(base, cfg); err != nil {
+			log.Fatalf("save config: %v", err)
+		}
+	}
+
+	logger, err := logging.New(cfg.LogLevel, cfg.LogPath)
+	if err != nil {
+		log.Fatalf("init logger: %v", err)
+	}
+	defer logger.Close()
+	if cfgErr != nil {
+		logger.Error("load config: " + cfgErr.Error())
+	}
+
+	hist, err := history.New(base)
+	if err != nil {
+		logger.Error("history: " + err.Error())
+		os.Exit(1)
+	}
+	defer hist.Close()
+
+	mgr := app.NewSessionManager(base, logger, cfg.Concurrency, &cfg, hist)
+	defer mgr.Close()
+
+	args := flag.Args()
+	if len(args) < 1 {
+		usage()
+		os.Exit(1)
+	}
+
+	switch args[0] {
+	case "run":
+		runFS := flag.NewFlagSet("run", flag.ExitOnError)
+		model := runFS.String("model", "", "model to run")
+		prompt := runFS.String("prompt", "", "prompt text")
+		runFS.Parse(args[1:])
+		if *model == "" || *prompt == "" {
+			fmt.Fprintln(os.Stderr, "model and prompt required")
+			os.Exit(1)
+		}
+		if err := runPrompt(mgr, *model, *prompt); err != nil {
+			logger.Error(err.Error())
+			os.Exit(1)
+		}
+	case "history":
+		if len(args) < 2 {
+			usage()
+			os.Exit(1)
+		}
+		switch args[1] {
+		case "export":
+			data, err := hist.Export()
+			if err != nil {
+				logger.Error("export history: " + err.Error())
+				os.Exit(1)
+			}
+			os.Stdout.Write(data)
+		case "import":
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				logger.Error("read stdin: " + err.Error())
+				os.Exit(1)
+			}
+			if err := hist.Import(data); err != nil {
+				logger.Error("import history: " + err.Error())
+				os.Exit(1)
+			}
+		default:
+			usage()
+			os.Exit(1)
+		}
+	default:
+		usage()
+		os.Exit(1)
+	}
+}
+
+func runPrompt(mgr *app.SessionManager, model, prompt string) error {
+	id, err := mgr.AddSession(model, prompt, []string{prompt})
+	if err != nil {
+		return err
+	}
+	ch, err := mgr.OutputChannel(id)
+	if err != nil {
+		return err
+	}
+	for line := range ch {
+		fmt.Println(line)
+	}
+	return nil
+}

--- a/cmd/cliwrap/main_test.go
+++ b/cmd/cliwrap/main_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"cli-wrapper/internal/app"
+)
+
+func TestRunCommandUpdatesConfig(t *testing.T) {
+	home := t.TempDir()
+	os.Setenv("HOME", home)
+	defer os.Unsetenv("HOME")
+
+	work := t.TempDir()
+	repoRoot, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	cmd := exec.Command("go", "run", "./cmd/cliwrap", "-concurrency", "2", "-workdir", work, "run", "-model", "echo", "-prompt", "hello")
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run: %v output %s", err, out)
+	}
+	if !strings.Contains(string(out), "hello") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+	base, err := app.AppDir()
+	if err != nil {
+		t.Fatalf("app dir: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(base, "config", "config.json"))
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var cfg app.Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cfg.Concurrency != 2 || cfg.WorkingDir != work {
+		t.Fatalf("config not updated: %+v", cfg)
+	}
+}
+
+func TestHistoryExportImport(t *testing.T) {
+	home1 := t.TempDir()
+	os.Setenv("HOME", home1)
+	defer os.Unsetenv("HOME")
+
+	repoRoot, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	cmdRun := exec.Command("go", "run", "./cmd/cliwrap", "run", "-model", "echo", "-prompt", "one")
+	cmdRun.Dir = repoRoot
+	cmdRun.Run()
+	exportCmd := exec.Command("go", "run", "./cmd/cliwrap", "history", "export")
+	exportCmd.Dir = repoRoot
+	exp, err := exportCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	if !bytes.Contains(exp, []byte("one")) {
+		t.Fatalf("missing export data: %s", exp)
+	}
+
+	home2 := t.TempDir()
+	os.Setenv("HOME", home2)
+	cmd := exec.Command("go", "run", "./cmd/cliwrap", "history", "import")
+	cmd.Dir = repoRoot
+	cmd.Stdin = bytes.NewReader(exp)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("import: %v output %s", err, out)
+	}
+	verifyCmd := exec.Command("go", "run", "./cmd/cliwrap", "history", "export")
+	verifyCmd.Dir = repoRoot
+	out, err := verifyCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("export2: %v", err)
+	}
+	if !bytes.Contains(out, []byte("one")) {
+		t.Fatalf("imported record missing: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- add new `cliwrap` command to run models and manage history
- persist concurrency and working directory via flags
- document usage in README
- test `cliwrap` command

## Testing
- `go vet ./...`
- `go test -race ./...`


------
https://chatgpt.com/codex/tasks/task_e_686244702884832abd1eee7214c194d5