### PR TITLE
Add session metrics polling and history API

### DIFF
--- a/frontend/src/__tests__/SessionChart.test.tsx
+++ b/frontend/src/__tests__/SessionChart.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+import SessionChart from "../components/SessionChart";
+
+vi.stubGlobal("fetch", vi.fn());
+
+it("renders metric lines", async () => {
+  (fetch as any).mockResolvedValueOnce({
+    ok: true,
+    json: async () => [{ id: "1", timestamp: "t", cpu: 10, memory: 20 }],
+  });
+  render(<SessionChart id="1" />);
+  await waitFor(() => {
+    expect(screen.getByRole("img")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/SessionChart.tsx
+++ b/frontend/src/components/SessionChart.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+
+interface Metric {
+  id: string;
+  timestamp: string;
+  cpu: number;
+  memory: number;
+}
+
+export default function SessionChart({ id }: { id: string }) {
+  const [metrics, setMetrics] = useState<Metric[]>([]);
+
+  useEffect(() => {
+    const fetchMetrics = async () => {
+      const res = await fetch(`/resource/session/${encodeURIComponent(id)}`);
+      if (res.ok) {
+        setMetrics(await res.json());
+      }
+    };
+    fetchMetrics();
+  }, [id]);
+
+  const width = 200;
+  const height = 80;
+  const points = (key: "cpu" | "memory") =>
+    metrics
+      .map((m, i) => {
+        const x = (i / Math.max(metrics.length - 1, 1)) * width;
+        const y = height - ((m[key] as number) / 100) * height;
+        return `${x},${y}`;
+      })
+      .join(" ");
+
+  return (
+    <svg width={width} height={height} className="border" role="img">
+      {metrics.length > 0 && (
+        <>
+          <polyline
+            fill="none"
+            stroke="blue"
+            strokeWidth="2"
+            points={points("cpu")}
+          />
+          <polyline
+            fill="none"
+            stroke="green"
+            strokeWidth="2"
+            points={points("memory")}
+          />
+        </>
+      )}
+    </svg>
+  );
+}

--- a/internal/history/store_test.go
+++ b/internal/history/store_test.go
@@ -1,50 +1,69 @@
 package history
 
 import (
-    "encoding/json"
-    "testing"
+	"encoding/json"
+	"testing"
 )
 
 func TestStoreCRUD(t *testing.T) {
-    dir := t.TempDir()
-    s, err := New(dir)
-    if err != nil {
-        t.Fatalf("new store: %v", err)
-    }
-    defer s.Close()
+	dir := t.TempDir()
+	s, err := New(dir)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	defer s.Close()
 
-    r := Record{ID: "1", Prompt: "hi", Response: "hello", Model: "openai", Success: true}
-    if err := s.Add(r); err != nil {
-        t.Fatalf("add: %v", err)
-    }
-    all, err := s.All()
-    if err != nil || len(all) != 1 {
-        t.Fatalf("all: %v len=%d", err, len(all))
-    }
+	r := Record{ID: "1", Prompt: "hi", Response: "hello", Model: "openai", Success: true}
+	if err := s.Add(r); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	all, err := s.All()
+	if err != nil || len(all) != 1 {
+		t.Fatalf("all: %v len=%d", err, len(all))
+	}
 
-    res, err := s.Search("hello", 10)
-    if err != nil || len(res) == 0 {
-        t.Fatalf("search: %v len=%d", err, len(res))
-    }
+	res, err := s.Search("hello", 10)
+	if err != nil || len(res) == 0 {
+		t.Fatalf("search: %v len=%d", err, len(res))
+	}
 
-    data, err := s.Export()
-    if err != nil {
-        t.Fatalf("export: %v", err)
-    }
+	data, err := s.Export()
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
 
-    // import into new store
-    s2, err := New(t.TempDir())
-    if err != nil {
-        t.Fatalf("new2: %v", err)
-    }
-    defer s2.Close()
-    if err := s2.Import(data); err != nil {
-        t.Fatalf("import: %v", err)
-    }
-    all2, _ := s2.All()
-    if len(all2) != 1 {
-        b, _ := json.Marshal(all2)
-        t.Fatalf("imported len=%d data=%s", len(all2), string(b))
-    }
+	// import into new store
+	s2, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("new2: %v", err)
+	}
+	defer s2.Close()
+	if err := s2.Import(data); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	all2, _ := s2.All()
+	if len(all2) != 1 {
+		b, _ := json.Marshal(all2)
+		t.Fatalf("imported len=%d data=%s", len(all2), string(b))
+	}
 }
 
+func TestMetrics(t *testing.T) {
+	dir := t.TempDir()
+	s, err := New(dir)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	defer s.Close()
+	m := Metric{ID: "1", CPU: 10, Memory: 20}
+	if err := s.AddMetric(m); err != nil {
+		t.Fatalf("add metric: %v", err)
+	}
+	metrics, err := s.Metrics("1")
+	if err != nil || len(metrics) != 1 {
+		t.Fatalf("metrics: %v len=%d", err, len(metrics))
+	}
+	if metrics[0].CPU != 10 || metrics[0].Memory != 20 {
+		t.Fatalf("unexpected metric %#v", metrics[0])
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -52,6 +52,18 @@ func TestEndpoints(t *testing.T) {
 		t.Fatalf("unexpected usage: %v", usage)
 	}
 
+	if err := hist.AddMetric(history.Metric{ID: "sid", CPU: 1, Memory: 2}); err != nil {
+		t.Fatalf("add metric: %v", err)
+	}
+	resp, err = http.Get(ts.URL + "/resource/session/sid")
+	if err != nil {
+		t.Fatalf("session metrics: %v", err)
+	}
+	var metrics []history.Metric
+	if err := json.NewDecoder(resp.Body).Decode(&metrics); err != nil || len(metrics) != 1 {
+		t.Fatalf("decode metrics: %v len=%d", err, len(metrics))
+	}
+
 	resp, err = http.Get(ts.URL + "/theme")
 	if err != nil {
 		t.Fatalf("theme: %v", err)


### PR DESCRIPTION
## Summary
- extend telemetry with PollProcess for periodic usage metrics
- store per-session metrics in SessionManager and persist to sqlite
- provide history store methods to add/query metrics
- expose `/resource/session/{id}` endpoint
- visualize metrics with new `SessionChart` React component
- update tests for metrics functionality

## Testing
- `go vet ./...`
- `go test -race ./...`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862693aeb6c832ab97bc1bf398a945c