### PR TITLE
refactor to use PrepareDirectories base path

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,6 +11,7 @@ import (
 )
 
 func main() {
+	// base is the root path containing config, logs and state directories.
 	base, err := app.PrepareDirectories()
 	if err != nil {
 		log.Printf("prepare dirs: %v", err)

--- a/cmd/wailsapp/main.go
+++ b/cmd/wailsapp/main.go
@@ -13,6 +13,7 @@ import (
 )
 
 func main() {
+	// base is the root path containing config, logs and state directories.
 	base, err := app.PrepareDirectories()
 	if err != nil {
 		log.Printf("prepare dirs: %v", err)

--- a/cmd/wailsapp/main_test.go
+++ b/cmd/wailsapp/main_test.go
@@ -14,9 +14,9 @@ func TestAppStartupLogFailure(t *testing.T) {
 	os.Setenv("HOME", home)
 	defer os.Unsetenv("HOME")
 
-	base, err := app.AppDir()
+	base, err := app.PrepareDirectories()
 	if err != nil {
-		t.Fatalf("app dir: %v", err)
+		t.Fatalf("prep dirs: %v", err)
 	}
 	cfgDir := filepath.Join(base, "config")
 	if err := os.MkdirAll(cfgDir, 0o755); err != nil {


### PR DESCRIPTION
## Summary
- capture application base directory with `app.PrepareDirectories` in both server and wails app entrypoints
- adjust tests for new helper
- add comments clarifying role of the base path

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68626d29bc70832ab5478382a04c873f