### PR TITLE
Add streaming typing animation

### DIFF
--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import { vi } from 'vitest';
+import { vi, beforeAll, beforeEach, describe, it, expect } from 'vitest';
+import { fireEvent } from '@testing-library/react';
 import App from '../App';
 
 const events: Record<string, (data: any) => void> = {};
@@ -13,6 +14,16 @@ vi.mock('@wailsio/runtime', () => ({
 beforeAll(() => {
   vi.stubGlobal('fetch', vi.fn());
   (global as any).window.backend = { RunPrompt: vi.fn() };
+  class WS {
+    static instances: WS[] = [];
+    onmessage: ((e: MessageEvent) => void) | null = null;
+    constructor(url: string) {
+      WS.instances.push(this);
+    }
+    send() {}
+    close() {}
+  }
+  vi.stubGlobal('WebSocket', WS as any);
 });
 
 beforeEach(() => {
@@ -29,5 +40,24 @@ describe('App logging', () => {
     await waitFor(() => {
       expect(screen.getByRole('alert')).toHaveTextContent('Model switched from old to new');
     });
+  });
+
+  it('animates streamed characters', async () => {
+    vi.useFakeTimers();
+    (fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({ concurrency: 1, workingDir: '' }) });
+    render(<App />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'hi' } });
+    (window.backend.RunPrompt as any).mockResolvedValueOnce('id1');
+    fireEvent.click(screen.getByText('Send'));
+    const ws = (global as any).WebSocket.instances[0] as any;
+    ws.onmessage?.({ data: 'h' });
+    ws.onmessage?.({ data: 'i' });
+    ws.onmessage?.({ data: '\n' });
+    vi.advanceTimersByTime(100);
+    await waitFor(() => {
+      expect(screen.getByText(/hi/)).toBeInTheDocument();
+    });
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary
- stream CLI output to a new `/streamchars` websocket
- animate responses character-by-character in React respecting reduced-motion
- style response pane for light/dark themes
- add unit tests for new server endpoint and React animation

## Testing
- `go vet ./...`
- `go test -race ./...`
- `npm test --prefix frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68626f6f0a88832aafb3f005d37449b2