### PR TITLE
Add billing link component

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import ModelSelector from "./components/ModelSelector";
 import ResourceMeter from "./components/ResourceMeter";
 import ThemeToggle from "./components/ThemeToggle";
 import HistoryViewer from "./components/HistoryViewer";
+import BillingLink from "./components/BillingLink";
 
 function App() {
   const [prompt, setPrompt] = useState("");
@@ -107,6 +108,7 @@ function App() {
           <ModelSelector selected={model} onChange={setModel} />
           <div className="flex items-center space-x-2">
             <ResourceMeter />
+            <BillingLink />
             <ThemeToggle />
             <button
               className="border rounded px-2 py-1"

--- a/frontend/src/__tests__/BillingLink.test.tsx
+++ b/frontend/src/__tests__/BillingLink.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { vi, beforeEach, it, describe, expect } from "vitest";
+import BillingLink from "../components/BillingLink";
+
+vi.stubGlobal("fetch", vi.fn());
+const openURL = vi.fn();
+vi.mock("@wailsio/runtime", () => ({ OpenURL: openURL }));
+
+beforeEach(() => {
+  (fetch as any).mockReset();
+  openURL.mockReset();
+});
+
+describe("BillingLink", () => {
+  it("fetches info and opens url", async () => {
+    (fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        tool: "openai",
+        url: "https://billing",
+        usage: { total_granted: 10, total_used: 3, total_available: 7 },
+      }),
+    });
+
+    render(<BillingLink />);
+    await waitFor(() => screen.getByText("View Billing"));
+    expect(screen.getByLabelText("usage")).toHaveTextContent("Used 3.00 / 10.00");
+    screen.getByText("View Billing").click();
+    expect(openURL).toHaveBeenCalledWith("https://billing");
+  });
+});

--- a/frontend/src/components/BillingLink.tsx
+++ b/frontend/src/components/BillingLink.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import { OpenURL } from "@wailsio/runtime";
+
+interface UsageTotals {
+  total_granted: number;
+  total_used: number;
+  total_available: number;
+}
+
+interface BillingResponse {
+  tool: string;
+  url: string;
+  usage?: UsageTotals;
+}
+
+export default function BillingLink() {
+  const [info, setInfo] = useState<BillingResponse | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch("/billing");
+        if (res.ok) {
+          const data: BillingResponse = await res.json();
+          setInfo(data);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, []);
+
+  if (!info) return null;
+
+  const handleOpen = () => {
+    OpenURL(info.url);
+  };
+
+  return (
+    <div className="flex items-center space-x-2">
+      {info.usage && (
+        <span className="text-sm" aria-label="usage">
+          Used {info.usage.total_used.toFixed(2)} / {info.usage.total_granted.toFixed(2)}
+        </span>
+      )}
+      <button className="border rounded px-2 py-1" onClick={handleOpen}>
+        View Billing
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `BillingLink` component to fetch `/billing`
- open provider URL via `@wailsio/runtime`
- show usage totals when available
- include new component in the top-right of the app UI
- test billing component behavior

## Testing
- `npm test --prefix frontend --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68627320f9d0832aac9ff03e0916b008