### PR TITLE
Highlight previous model selection

### DIFF
--- a/frontend/src/__tests__/ModelSelector.test.tsx
+++ b/frontend/src/__tests__/ModelSelector.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { vi, describe, it, beforeEach, expect } from "vitest";
+import ModelSelector from "../components/ModelSelector";
+
+vi.stubGlobal("fetch", vi.fn());
+
+describe("ModelSelector", () => {
+  beforeEach(() => {
+    (fetch as any).mockReset();
+  });
+
+  it("highlights on selection change", async () => {
+    vi.useFakeTimers();
+    (fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ["a", "b"] });
+    const { rerender } = render(<ModelSelector selected="a" onChange={() => {}} />);
+    await waitFor(() => screen.getByRole("combobox"));
+    rerender(<ModelSelector selected="b" onChange={() => {}} />);
+    const select = screen.getByRole("combobox");
+    expect(select.className).toMatch(/border-blue-500/);
+    vi.advanceTimersByTime(300);
+    expect(select.className).not.toMatch(/border-blue-500/);
+    vi.useRealTimers();
+  });
+});

--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 
 interface Props {
   selected: string;
@@ -7,6 +7,8 @@ interface Props {
 
 export default function ModelSelector({ selected, onChange }: Props) {
   const [models, setModels] = useState<string[]>([]);
+  const prev = useRef<string>(selected);
+  const [flash, setFlash] = useState(false);
 
   useEffect(() => {
     const fetchModels = async () => {
@@ -23,9 +25,18 @@ export default function ModelSelector({ selected, onChange }: Props) {
     fetchModels();
   }, []);
 
+  useEffect(() => {
+    if (prev.current !== selected) {
+      setFlash(true);
+      const id = setTimeout(() => setFlash(false), 300);
+      prev.current = selected;
+      return () => clearTimeout(id);
+    }
+  }, [selected]);
+
   return (
     <select
-      className="border rounded px-2 py-1"
+      className={`border rounded px-2 py-1 transition-colors ${flash ? 'border-blue-500 bg-blue-50' : ''}`}
       value={selected}
       onChange={(e) => onChange(e.target.value)}
     >


### PR DESCRIPTION
## Summary
- track previous model in ModelSelector
- highlight the `<select>` element when switching models
- add unit test for the new highlight behavior

## Testing
- `npm test` *(fails: vitest not found)*
- `go vet ./...`
- `go test -race ./...`

------
https://chatgpt.com/codex/tasks/task_e_68627484d8e0832a8bf6c081b93a2ee2