### PR TITLE
Add transition utilities

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -98,7 +98,7 @@ function App() {
   };
 
   return (
-    <div className="flex h-screen">
+    <div className="flex h-screen transition-colors duration-300">
       <aside className="w-48 bg-gray-100 dark:bg-gray-800 overflow-y-auto">
         <SessionList />
         <HistoryViewer />
@@ -119,12 +119,12 @@ function App() {
           </div>
         </div>
         {alert && (
-          <div className="text-yellow-600" role="alert">
+          <div className="text-yellow-600 transition-opacity duration-300" role="alert">
             {alert}
           </div>
         )}
         {showSettings && (
-          <div className="border p-2 rounded space-y-2" role="dialog">
+          <div className="border p-2 rounded space-y-2 transition-all duration-300" role="dialog">
             <div>
               <label className="block mb-1">Concurrent Agents</label>
               <input

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -39,7 +39,7 @@ export default function ThemeToggle() {
   };
 
   return (
-    <button className="border rounded px-2 py-1" onClick={toggle} aria-label="Toggle theme">
+    <button className="border rounded px-2 py-1 transition-colors" onClick={toggle} aria-label="Toggle theme">
       {theme === "light" ? "Dark Mode" : "Light Mode"}
     </button>
   );


### PR DESCRIPTION
## Summary
- enhance root and settings panel with `transition` classes
- smooth theme toggle interaction

## Testing
- `go vet ./...`
- `go test -race ./...` *(fails: race detected during tests)*
- `npm test --prefix frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862764f2220832a8a0b86388787410f