### PR TITLE
reuse cached process for metrics

### DIFF
--- a/internal/app/session_manager.go
+++ b/internal/app/session_manager.go
@@ -187,7 +187,12 @@ func (m *SessionManager) run(req sessionRequest) {
 
 func (m *SessionManager) monitor(s *Session) {
 	ticker := time.NewTicker(time.Duration(m.cfg.PollInterval) * time.Second)
-	defer ticker.Stop()
+	defer func() {
+		ticker.Stop()
+		if s.proc != nil {
+			s.proc = nil
+		}
+	}()
 	for {
 		select {
 		case <-s.done:
@@ -196,7 +201,7 @@ func (m *SessionManager) monitor(s *Session) {
 			if s.proc == nil {
 				continue
 			}
-			usage, err := telemetry.ReadProcess(s.proc.Pid)
+			usage, err := telemetry.ReadProcess(s.proc)
 			if err != nil {
 				m.logger.Error(fmt.Sprintf("metrics %s: %v", s.ID, err))
 				continue

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -33,11 +33,11 @@ func Read() (Usage, error) {
 	return Usage{CPU: cpuVal, Memory: vm.UsedPercent}, nil
 }
 
-// ReadProcess returns CPU and memory usage for the given process ID.
-func ReadProcess(pid int32) (Usage, error) {
-	p, err := process.NewProcess(pid)
-	if err != nil {
-		return Usage{}, fmt.Errorf("new process: %w", err)
+// ReadProcess returns CPU and memory usage for the provided process.
+// It expects a valid gopsutil process handle.
+func ReadProcess(p *process.Process) (Usage, error) {
+	if p == nil {
+		return Usage{}, fmt.Errorf("nil process")
 	}
 	cpuPercent, err := p.CPUPercent()
 	if err != nil {

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/shirou/gopsutil/v3/process"
 )
 
 func TestRead(t *testing.T) {
@@ -21,7 +23,11 @@ func TestRead(t *testing.T) {
 }
 
 func TestReadProcess(t *testing.T) {
-	u, err := ReadProcess(int32(os.Getpid()))
+	p, err := process.NewProcess(int32(os.Getpid()))
+	if err != nil {
+		t.Fatalf("new process: %v", err)
+	}
+	u, err := ReadProcess(p)
 	if err != nil {
 		t.Fatalf("read process: %v", err)
 	}


### PR DESCRIPTION
## Summary
- keep a session's `process.Process` handle
- update telemetry to accept an existing process object
- adjust metrics tests
- release the handle when monitoring ends

## Testing
- `go vet ./...`
- `go test -race ./internal/... -run TestReadProcess -count=1`
- `npm test --prefix frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b4c3bcc4832ab817dc1ae254e01b