### PR TITLE
Fix handle cleanup in metrics and session management

### DIFF
--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -39,6 +39,38 @@ func TestReadProcess(t *testing.T) {
 	}
 }
 
+// fdCount returns the number of open file descriptors for the current process.
+func fdCount() (int, error) {
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		return 0, err
+	}
+	return len(entries), nil
+}
+
+func TestReadProcess_NoLeak(t *testing.T) {
+	p, err := process.NewProcess(int32(os.Getpid()))
+	if err != nil {
+		t.Fatalf("new process: %v", err)
+	}
+	start, err := fdCount()
+	if err != nil {
+		t.Skipf("fd count unsupported: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		if _, err := ReadProcess(p); err != nil {
+			t.Fatalf("read process: %v", err)
+		}
+	}
+	end, err := fdCount()
+	if err != nil {
+		t.Fatalf("fd count: %v", err)
+	}
+	if end > start {
+		t.Fatalf("fd leak: start %d end %d", start, end)
+	}
+}
+
 func TestPollProcess(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	ch, err := PollProcess(ctx, int32(os.Getpid()), 10*time.Millisecond)


### PR DESCRIPTION
## Summary
- add `processHandle` interface and helper to release OS handles
- clean up process handles in polling loop
- ensure SessionManager releases process handles when sessions end
- test repeated `ReadProcess` calls don't leak handles

## Testing
- `go vet ./...`
- `go test -race ./internal/telemetry`
- `go test -race ./...` *(fails: race detected in TestSessionTerminate)*

------
https://chatgpt.com/codex/tasks/task_e_6862b4bc90fc832ab145cc525fcdf776