### PR TITLE
Fix Windows throttle handle

### DIFF
--- a/internal/app/throttle_windows.go
+++ b/internal/app/throttle_windows.go
@@ -12,5 +12,10 @@ func throttleProcess(cmd *exec.Cmd) error {
 	if cmd.Process == nil {
 		return fmt.Errorf("process not started")
 	}
-	return windows.SetPriorityClass(windows.Handle(cmd.Process.Pid), windows.BELOW_NORMAL_PRIORITY_CLASS)
+	handle, err := windows.OpenProcess(windows.PROCESS_SET_INFORMATION, false, uint32(cmd.Process.Pid))
+	if err != nil {
+		return fmt.Errorf("open process: %w", err)
+	}
+	defer windows.CloseHandle(handle)
+	return windows.SetPriorityClass(handle, windows.BELOW_NORMAL_PRIORITY_CLASS)
 }

--- a/internal/app/throttle_windows_test.go
+++ b/internal/app/throttle_windows_test.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package app
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// Test that throttleProcess returns an error when the process has not been started.
+func TestThrottleProcessNotStarted(t *testing.T) {
+	cmd := exec.Command("cmd.exe")
+	if err := throttleProcess(cmd); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// Test that throttleProcess propagates errors from OpenProcess.
+func TestThrottleProcessOpenError(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/C", "exit 0")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	// Wait for the process to exit so OpenProcess fails.
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	if err := throttleProcess(cmd); err == nil {
+		t.Fatal("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- use `windows.OpenProcess` to get a process handle
- close the handle after setting the priority class
- handle errors from `OpenProcess`
- add Windows-only unit tests

## Testing
- `go test ./internal/app -run TestSanitizePrompt -count=1`
- `go vet ./...`
- `go test ./internal/app -run TestThrottleProcessNotStarted -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6863e60cccdc832abd133be63a4306e5