### PR TITLE
Refactor URLs for relative access

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,7 +32,7 @@ function App() {
   useEffect(() => {
     const load = async () => {
       try {
-        const res = await fetch("http://localhost:8080/config");
+        const res = await fetch("/config");
         if (res.ok) {
           const data = await res.json();
           setConcurrency(data.concurrency);
@@ -82,7 +82,8 @@ function App() {
     const id = await window.backend.RunPrompt(model, prompt);
     setResponse("");
     queueRef.current = [];
-    const ws = new WebSocket(`ws://localhost:8080/streamchars?id=${id}`);
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const ws = new WebSocket(`${protocol}//${window.location.host}/streamchars?id=${id}`);
     ws.onmessage = (e) => {
       queueRef.current.push(...(maskSecrets(e.data)));
     };
@@ -90,7 +91,7 @@ function App() {
 
   const saveSettings = async () => {
     try {
-      await fetch("http://localhost:8080/config", {
+      await fetch("/config", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -13,7 +13,7 @@ export default function ModelSelector({ selected, onChange }: Props) {
   useEffect(() => {
     const fetchModels = async () => {
       try {
-        const res = await fetch("http://localhost:8080/models");
+        const res = await fetch("/models");
         if (res.ok) {
           const data = await res.json();
           setModels(data);

--- a/frontend/src/components/ResourceMeter.tsx
+++ b/frontend/src/components/ResourceMeter.tsx
@@ -7,7 +7,7 @@ export default function ResourceMeter() {
   useEffect(() => {
     const fetchUsage = async () => {
       try {
-        const res = await fetch("http://localhost:8080/resource");
+        const res = await fetch("/resource");
         if (res.ok) {
           const data = await res.json();
           setCpu(data.cpu);

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -3,7 +3,8 @@ import { useEffect, useState } from "react";
 function SessionItem({ id }: { id: string }) {
   const [lines, setLines] = useState<string[]>([]);
   useEffect(() => {
-    const ws = new WebSocket(`ws://localhost:8080/stream?id=${id}`);
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const ws = new WebSocket(`${protocol}//${window.location.host}/stream?id=${id}`);
     ws.onmessage = (e) => setLines((p) => [...p, e.data as string]);
     return () => ws.close();
   }, [id]);
@@ -21,7 +22,7 @@ export default function SessionList() {
   useEffect(() => {
     const fetchSessions = async () => {
       try {
-        const res = await fetch("http://localhost:8080/sessions");
+        const res = await fetch("/sessions");
         if (res.ok) {
           const data = await res.json();
           setSessions(data);

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -6,7 +6,7 @@ export default function ThemeToggle() {
   useEffect(() => {
     const load = async () => {
       try {
-        const res = await fetch("http://localhost:8080/theme");
+        const res = await fetch("/theme");
         if (res.ok) {
           const data = await res.json();
           if (data.theme === "light" || data.theme === "dark") {
@@ -28,7 +28,7 @@ export default function ThemeToggle() {
     const next = theme === "light" ? "dark" : "light";
     setTheme(next);
     try {
-      await fetch("http://localhost:8080/theme", {
+      await fetch("/theme", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ theme: next }),


### PR DESCRIPTION
## Summary
- use relative API paths in React frontend
- derive ws/wss protocol from `window.location`
- adjust websocket construction to match host

## Testing
- `npm test --prefix frontend` *(fails: Test timed out in 5000ms)*

------
https://chatgpt.com/codex/tasks/task_e_68663ce0307c832aa7f9d89dffffd097