### PR TITLE
Refactor session manager API and fix race

### DIFF
--- a/cmd/cliwrap/main.go
+++ b/cmd/cliwrap/main.go
@@ -70,7 +70,7 @@ func main() {
 	}
 	defer hist.Close()
 
-	mgr := app.NewSessionManager(base, logger, cfg.Concurrency, &cfg, hist)
+	mgr := app.NewSessionManager(logger, cfg.Concurrency, &cfg, hist)
 	defer mgr.Close()
 
 	args := flag.Args()

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -41,7 +41,7 @@ func main() {
 	}
 	defer hist.Close()
 
-	mgr := app.NewSessionManager(base, logger, cfg.Concurrency, &cfg, hist)
+	mgr := app.NewSessionManager(logger, cfg.Concurrency, &cfg, hist)
 	defer mgr.Close()
 
 	srv := server.New(mgr, logger, base, &cfg, hist)

--- a/cmd/wailsapp/main.go
+++ b/cmd/wailsapp/main.go
@@ -42,7 +42,7 @@ func main() {
 	}
 	defer hist.Close()
 
-	mgr := app.NewSessionManager(base, logger, cfg.Concurrency, &cfg, hist)
+	mgr := app.NewSessionManager(logger, cfg.Concurrency, &cfg, hist)
 	defer mgr.Close()
 	backend := app.NewBackend(mgr, logger, &cfg)
 	opts := &options.App{Bind: []interface{}{backend}, OnStartup: backend.Startup}

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -32,7 +32,7 @@ func DetectCLITools() ([]string, error) {
 }
 
 // InvokeTool runs the given CLI with args and logs the invocation.
-func InvokeTool(tool string, args []string, baseDir string) error {
+func InvokeTool(tool string, args []string) error {
 	logger, err := logging.New("info", "")
 	if err != nil {
 		return err

--- a/internal/app/session_manager_test.go
+++ b/internal/app/session_manager_test.go
@@ -18,7 +18,7 @@ func TestSessionManagerQueue(t *testing.T) {
 	os.MkdirAll(filepath.Join(base, "state"), 0o755)
 	hist, _ := history.New(base)
 	defer hist.Close()
-	m := NewSessionManager(t.TempDir(), logger, 1, cfg, hist)
+	m := NewSessionManager(logger, 1, cfg, hist)
 	defer m.Close()
 
 	id1, err := m.AddSession("sh", "", []string{"-c", "sleep 0.1"})
@@ -45,7 +45,7 @@ func TestSessionTerminate(t *testing.T) {
 	os.MkdirAll(filepath.Join(base, "state"), 0o755)
 	hist, _ := history.New(base)
 	defer hist.Close()
-	m := NewSessionManager(t.TempDir(), logger, 1, cfg, hist)
+	m := NewSessionManager(logger, 1, cfg, hist)
 	defer m.Close()
 
 	id, err := m.AddSession("sh", "", []string{"-c", "sleep 2"})
@@ -65,7 +65,7 @@ func TestSessionWorkingDir(t *testing.T) {
 	os.MkdirAll(filepath.Join(base, "state"), 0o755)
 	hist, _ := history.New(base)
 	defer hist.Close()
-	m := NewSessionManager(t.TempDir(), logger, 1, cfg, hist)
+	m := NewSessionManager(logger, 1, cfg, hist)
 	defer m.Close()
 
 	if _, err := m.AddSession("sh", "", []string{"-c", "echo test"}); err != nil {
@@ -84,7 +84,7 @@ func TestSessionStreaming(t *testing.T) {
 	os.MkdirAll(filepath.Join(base, "state"), 0o755)
 	hist, _ := history.New(base)
 	defer hist.Close()
-	m := NewSessionManager(t.TempDir(), logger, 1, cfg, hist)
+	m := NewSessionManager(logger, 1, cfg, hist)
 	defer m.Close()
 
 	script := filepath.Join(t.TempDir(), "script.sh")

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -24,7 +24,7 @@ func TestEndpoints(t *testing.T) {
 	cfg := &app.Config{Concurrency: 1, Theme: "light", CPUThreshold: 50, MemoryThreshold: 50, PollInterval: 2, LogLevel: "info", LogPath: filepath.Join(dir, "log.txt"), WorkingDir: dir}
 	hist, _ := history.New(dir)
 	defer hist.Close()
-	mgr := app.NewSessionManager(dir, logger, 1, cfg, hist)
+	mgr := app.NewSessionManager(logger, 1, cfg, hist)
 	defer mgr.Close()
 
 	srv := New(mgr, logger, dir, cfg, hist)
@@ -192,7 +192,7 @@ func TestStreamChars(t *testing.T) {
 	cfg := &app.Config{Concurrency: 1, Theme: "light", CPUThreshold: 50, MemoryThreshold: 50, PollInterval: 2, LogLevel: "info", LogPath: filepath.Join(dir, "log.txt"), WorkingDir: dir}
 	hist, _ := history.New(dir)
 	defer hist.Close()
-	mgr := app.NewSessionManager(dir, logger, 1, cfg, hist)
+	mgr := app.NewSessionManager(logger, 1, cfg, hist)
 	defer mgr.Close()
 
 	script := filepath.Join(dir, "echoer")


### PR DESCRIPTION
## Summary
- remove unused `baseDir` argument from `NewSessionManager` and `InvokeTool`
- add mutexes to `Session` to prevent data races
- update server, wails app and cliwrap to call the new API
- adjust unit tests

## Testing
- `go vet ./...`
- `go test -race ./...`
- `npm test --prefix frontend` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68664b0a4ddc832a82d9c7957d434538