### PR TITLE
Allow dots in model names

### DIFF
--- a/internal/app/sanitize.go
+++ b/internal/app/sanitize.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 )
 
-var modelPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+// modelPattern defines allowable characters for model identifiers.
+// Models may contain letters, numbers, dashes, underscores and periods.
+var modelPattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
 // SanitizeModel validates allowed characters in model names.
 func SanitizeModel(model string) (string, error) {

--- a/internal/app/sanitize_test.go
+++ b/internal/app/sanitize_test.go
@@ -20,7 +20,17 @@ func TestSanitizeModel(t *testing.T) {
 	if _, err := SanitizeModel("../bad"); err == nil {
 		t.Error("expected error")
 	}
-	if m, err := SanitizeModel("good-model_1"); err != nil || m != "good-model_1" {
-		t.Errorf("unexpected result %v %v", m, err)
+	if _, err := SanitizeModel("bad model"); err == nil {
+		t.Error("expected error")
+	}
+	cases := []string{
+		"good-model_1",
+		"gpt-3.5-turbo",
+		"model.version_2",
+	}
+	for _, c := range cases {
+		if m, err := SanitizeModel(c); err != nil || m != c {
+			t.Errorf("unexpected result %v %v", m, err)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- loosen model regex to allow periods and other valid characters
- test common model names like `gpt-3.5-turbo`

## Testing
- `go vet ./...`
- `go test -race ./internal/app`
- `npm test --prefix frontend` *(fails: tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68665133f750832aaf756a201eb77f1c