### PR TITLE
Add CLIWRAP_TOOL preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ append lines dynamically so results appear incrementally.
 
 The application supports extensible CLI integrations via a plugin mechanism. Each plugin must implement the `plugins.Plugin` interface and register itself during initialization using `plugins.Register`. Registered plugins are automatically detected at runtime. See `internal/plugins/openai.go` and `internal/plugins/gemini.go` for reference implementations.
 
+To force the application to use a specific CLI, set the `CLIWRAP_TOOL` environment variable to the plugin name before launching. When set and the selected tool is available, `DetectCLITool` returns that tool instead of auto-detecting.
+
 ## `cliwrap` Command
 
 The `cliwrap` tool provides a minimal terminal interface for running a model and managing history.
@@ -137,4 +139,6 @@ Global flags `-concurrency` and `-workdir` update the same `config.json` used by
 ```bash
 cliwrap -concurrency 2 -workdir /tmp run -model sh -prompt "echo hi"
 ```
+
+You can override automatic CLI detection by exporting `CLIWRAP_TOOL` with the desired plugin name before running commands.
 

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"os"
 
 	"cli-wrapper/internal/logging"
 	"cli-wrapper/internal/plugins"
@@ -9,6 +10,13 @@ import (
 
 // DetectCLITool returns the first available CLI tool.
 func DetectCLITool() (string, error) {
+	if pref := os.Getenv("CLIWRAP_TOOL"); pref != "" {
+		if p, ok := plugins.Get(pref); ok {
+			if p.Detect() {
+				return p.Name(), nil
+			}
+		}
+	}
 	for _, p := range plugins.All() {
 		if p.Detect() {
 			return p.Name(), nil

--- a/internal/app/cli_test.go
+++ b/internal/app/cli_test.go
@@ -1,15 +1,40 @@
 package app
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestDetectCLIToolNone(t *testing.T) {
+	t.Setenv("CLIWRAP_TOOL", "")
 	if _, err := DetectCLITool(); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
 func TestDetectCLIToolsNone(t *testing.T) {
+	t.Setenv("CLIWRAP_TOOL", "")
 	if _, err := DetectCLITools(); err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestDetectCLIToolEnv(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "openai")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho ok"), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+oldPath)
+	t.Setenv("CLIWRAP_TOOL", "openai")
+
+	tool, err := DetectCLITool()
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if tool != "openai" {
+		t.Fatalf("got %s want openai", tool)
 	}
 }


### PR DESCRIPTION
## Summary
- allow specifying preferred CLI via `CLIWRAP_TOOL` env var
- respect the env var in `DetectCLITool`
- test env var handling
- document configuration in README

## Testing
- `go vet ./...`
- `go test ./internal/... ./cmd/cliwrap -run TestDetectCLIToolEnv -v`
- `npm test --prefix frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686653ce424c832abf08b3fff882f148