### PR TITLE
Fix API key masking regex and add tests

### DIFF
--- a/frontend/src/__tests__/maskSecrets.test.ts
+++ b/frontend/src/__tests__/maskSecrets.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { maskSecrets } from "../utils";
+
+describe("maskSecrets", () => {
+  it("masks 48-char OpenAI keys", () => {
+    const key = "sk-" + "a".repeat(48);
+    const result = maskSecrets(`prefix ${key} suffix`);
+    expect(result).toBe(`prefix ${"*".repeat(key.length)} suffix`);
+  });
+
+  it("masks longer OpenAI keys", () => {
+    const key = "sk-" + "b".repeat(60);
+    const result = maskSecrets(`test ${key}`);
+    expect(result).toBe(`test ${"*".repeat(key.length)}`);
+  });
+});

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,4 +1,6 @@
 export function maskSecrets(text: string): string {
-  const apiKeyPattern = /(sk-[a-zA-Z0-9]{10,})/g;
+  // Match OpenAI API keys which follow the sk-<48+ alphanumeric chars> format
+  // Keys may occasionally vary in length, so match 48 or more characters
+  const apiKeyPattern = /(sk-[A-Za-z0-9]{48,})/g;
   return text.replace(apiKeyPattern, (m) => '*'.repeat(m.length));
 }


### PR DESCRIPTION
## Summary
- tighten regex for OpenAI API keys
- add maskSecrets unit test covering different key lengths

## Testing
- `npm test --prefix frontend` *(fails: Test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686660b618d4832aab99a56b00bf6050