### PR TITLE
Improve OpenAI key masking

### DIFF
--- a/frontend/src/__tests__/maskSecrets.test.ts
+++ b/frontend/src/__tests__/maskSecrets.test.ts
@@ -2,15 +2,10 @@ import { describe, it, expect } from "vitest";
 import { maskSecrets } from "../utils";
 
 describe("maskSecrets", () => {
-  it("masks 48-char OpenAI keys", () => {
-    const key = "sk-" + "a".repeat(48);
+  const lengths = [48, 50, 60];
+  it.each(lengths)("masks OpenAI keys of length %i", (len) => {
+    const key = "sk-" + "a".repeat(len);
     const result = maskSecrets(`prefix ${key} suffix`);
     expect(result).toBe(`prefix ${"*".repeat(key.length)} suffix`);
-  });
-
-  it("masks longer OpenAI keys", () => {
-    const key = "sk-" + "b".repeat(60);
-    const result = maskSecrets(`test ${key}`);
-    expect(result).toBe(`test ${"*".repeat(key.length)}`);
   });
 });

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,6 +1,7 @@
 export function maskSecrets(text: string): string {
-  // Match OpenAI API keys which follow the sk-<48+ alphanumeric chars> format
-  // Keys may occasionally vary in length, so match 48 or more characters
-  const apiKeyPattern = /(sk-[A-Za-z0-9]{48,})/g;
+  // Match OpenAI API keys which follow the "sk-" prefix and consist of
+  // at least 48 alphanumeric characters. Word boundaries ensure that the
+  // entire key is replaced rather than just a substring.
+  const apiKeyPattern = /\bsk-[A-Za-z0-9]{48,}\b/g;
   return text.replace(apiKeyPattern, (m) => '*'.repeat(m.length));
 }


### PR DESCRIPTION
## Summary
- ensure masking regex matches OpenAI API key format
- test masking for multiple key lengths

## Testing
- `go vet ./...`
- `go test -race ./...` *(fails: context deadline)*
- `npm test --prefix frontend --silent` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_68666389ec18832a87694618115742c8