### PR TITLE
Fix env cleanup in app path tests

### DIFF
--- a/internal/app/paths_test.go
+++ b/internal/app/paths_test.go
@@ -7,7 +7,9 @@ import (
 )
 
 func TestAppDirForOS(t *testing.T) {
+	oldAppData := os.Getenv("APPDATA")
 	os.Setenv("APPDATA", `C:\\Data`)
+	defer os.Setenv("APPDATA", oldAppData)
 	path, err := appDirForOS("windows")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -17,7 +19,9 @@ func TestAppDirForOS(t *testing.T) {
 	}
 
 	home := t.TempDir()
+	oldHome := os.Getenv("HOME")
 	os.Setenv("HOME", home)
+	defer os.Setenv("HOME", oldHome)
 	path, err = appDirForOS("darwin")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
## Summary
- restore environment variables in `paths_test.go`

## Testing
- `go vet ./...`
- `go test -race ./...`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866678d17e0832aa7f25a900947cf41