### PR TITLE
Add single launch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ Run the generated binary on your platform:
 
 During development you can start a hot reload server with `wails dev`.
 
+### One-step build and launch
+
+Run `scripts/launch.sh` to automatically install prerequisites, build for your
+platform, and start the compiled application. All output is appended to
+`sentinel.log` in `/var/log` on Unix or `C:\Temp` on Windows. Set
+`SENTINEL_LOG_PATH` to override the log location.
+
 ## Session Manager
 
 The `internal/app` package now provides a `SessionManager` which limits concurrent

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Determine log path
+LOG_FILE="${SENTINEL_LOG_PATH:-}"
+if [ -z "$LOG_FILE" ]; then
+  case "$(uname -s)" in
+    CYGWIN*|MINGW*|MSYS*) LOG_FILE="$SystemDrive\\Temp\\sentinel.log" ;;
+    *) LOG_FILE="/var/log/sentinel.log" ;;
+  esac
+fi
+mkdir -p "$(dirname "$LOG_FILE")"
+
+utc_now() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+log() { echo "$(utc_now) launch.sh: $1" >> "$LOG_FILE"; }
+
+log "starting launch script"
+
+if [ -z "${LAUNCH_SKIP_INSTALL:-}" ]; then
+  log "installing prerequisites"
+  "$SCRIPT_DIR/install.sh" >> "$LOG_FILE" 2>&1
+fi
+
+if ! command -v wails >/dev/null 2>&1; then
+  log "wails CLI not found"
+  echo "Please run scripts/install.sh to install prerequisites." >&2
+  exit 1
+fi
+
+case "$(uname -s)" in
+  Linux*)   PLATFORM="linux/amd64";   BIN="./build/bin/ai-cli-ui" ;;
+  Darwin*)  PLATFORM="darwin/universal"; BIN="build/bin/ai-cli-ui.app" ;;
+  CYGWIN*|MINGW*|MSYS*) PLATFORM="windows/amd64"; BIN="build\\bin\\ai-cli-ui.exe" ;;
+  *) echo "Unsupported platform $(uname -s)" >&2; exit 1 ;;
+esac
+
+log "building for $PLATFORM"
+if ! wails build -platform "$PLATFORM" >> "$LOG_FILE" 2>&1; then
+  log "wails build failed"
+  exit 1
+fi
+
+if [ -n "${LAUNCH_NOP:-}" ]; then
+  log "dry run mode, skipping launch"
+  exit 0
+fi
+
+log "launching $BIN"
+if [ "$(uname -s)" = "Darwin" ]; then
+  open "$BIN" >> "$LOG_FILE" 2>&1 &
+else
+  "$BIN" >> "$LOG_FILE" 2>&1 &
+fi

--- a/scripts/launch_test.go
+++ b/scripts/launch_test.go
@@ -1,0 +1,46 @@
+package scripts
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestLaunchScriptDryRun(t *testing.T) {
+	repoRoot, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "sentinel.log")
+
+	// stub wails executable
+	wailsPath := filepath.Join(tmp, "wails")
+	content := "#!/bin/sh\n\necho wails \"$@\"\n"
+	if err := os.WriteFile(wailsPath, []byte(content), 0755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+
+	cmd := exec.Command("bash", filepath.Join(repoRoot, "scripts", "launch.sh"))
+	cmd.Env = append(os.Environ(),
+		"PATH="+tmp+":"+os.Getenv("PATH"),
+		"SENTINEL_LOG_PATH="+logPath,
+		"LAUNCH_SKIP_INSTALL=1",
+		"LAUNCH_NOP=1",
+	)
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run script: %v output %s", err, out)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !bytes.Contains(data, []byte("building")) {
+		t.Fatalf("expected build log, got %s", data)
+	}
+}


### PR DESCRIPTION
## Summary
- add a `launch.sh` script to install, build and run the desktop app
- document the new script in the README
- cover the script with a Go test

## Testing
- `go test ./...`
- `npm test --prefix frontend --silent` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68666816dd10832aa78265e6d05914a1