### PR TITLE
Document Windows launch procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,10 @@ During development you can start a hot reload server with `wails dev`.
 ### One-step build and launch
 
 Run `scripts/launch.sh` to automatically install prerequisites, build for your
-platform, and start the compiled application. All output is appended to
-`sentinel.log` in `/var/log` on Unix or `C:\Temp` on Windows. Set
-`SENTINEL_LOG_PATH` to override the log location.
+platform, and start the compiled application. Windows users should invoke this
+script from **Git Bash** or **WSL** so the Bash commands run correctly. All
+output is appended to `sentinel.log` in `/var/log` on Unix or `C:\Temp` on
+Windows. Set `SENTINEL_LOG_PATH` to override the log location.
 
 ## Session Manager
 


### PR DESCRIPTION
## Summary
- instruct Windows users to run launch.sh from Git Bash or WSL

## Testing
- `go vet ./...`
- `go test ./scripts -run TestLaunchScriptDryRun -race`
- `npm test --prefix frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68666e55b538832a8dcaadd58c2abc22