### PR TITLE
Fix Windows install script version checks

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -49,6 +49,7 @@ trap {
 
 $REQUIRED_GO = '1.24'
 $REQUIRED_NODE = '18'
+$NODE_PATCH = '18.20.8'
 
 function Version-GE {
     param([string]$Current, [string]$Required)
@@ -100,7 +101,7 @@ function Install-Node {
         Log 'Installing Node via Chocolatey'
         choco install -y nodejs-lts | Out-Null
     } else {
-        $url = 'https://nodejs.org/dist/latest-v18.x/node-v18.20.3-x64.msi'
+        $url = "https://nodejs.org/dist/v$NODE_PATCH/node-v$NODE_PATCH-x64.msi"
         $msi = Join-Path ([IO.Path]::GetTempPath()) 'node.msi'
         Log "Downloading Node from $url"
         Invoke-WebRequest -Uri $url -OutFile $msi -UseBasicParsing
@@ -110,6 +111,18 @@ function Install-Node {
 }
 
 function Install-Wails {
+    $wailsCmd = Get-Command wails -ErrorAction SilentlyContinue
+    if ($wailsCmd) {
+        try {
+            $out = (& wails version) -join ' '
+            if ($out -match 'v([0-9.]+)') {
+                Log "Wails $($Matches[1]) already installed"
+                return
+            }
+        } catch {
+            # continue install if version check fails
+        }
+    }
     Log 'Installing Wails CLI'
     & go install github.com/wailsapp/wails/v2/cmd/wails@latest | Out-Null
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -68,7 +68,7 @@ install_node() {
     echo "Installing Node.js"
     case "$OS" in
         linux)
-            curl -fsSL https://nodejs.org/dist/latest-v18.x/node-v18.20.3-linux-x64.tar.gz -o node.tgz
+            curl -fsSL https://nodejs.org/dist/v18.20.8/node-v18.20.8-linux-x64.tar.gz -o node.tgz
             sudo tar -C /usr/local --strip-components=1 -xzf node.tgz
             rm node.tgz
             ;;
@@ -77,7 +77,7 @@ install_node() {
                 brew install node@18
                 brew link --force --overwrite node@18
             else
-                curl -fsSL https://nodejs.org/dist/latest-v18.x/node-v18.20.3-darwin-x64.tar.gz -o node.tgz
+                curl -fsSL https://nodejs.org/dist/v18.20.8/node-v18.20.8-darwin-x64.tar.gz -o node.tgz
                 sudo tar -C /usr/local --strip-components=1 -xzf node.tgz
                 rm node.tgz
             fi


### PR DESCRIPTION
## Summary
- improve `install.ps1` to avoid reinstalling tools and use up-to-date Node link
- update cross-platform installer to use latest Node LTS

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`
- `go test ./scripts -run .`


------
https://chatgpt.com/codex/tasks/task_e_686683982b78832a86bd03ef8ee7aba1