### PR TITLE
Fix logging initialization in install.ps1

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,11 +1,6 @@
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
-if ($PSVersionTable.PSVersion.Major -lt 5) {
-    Write-Error 'PowerShell 5.1 or newer is required'
-    exit 1
-}
-
 $LogPath = $env:SENTINEL_LOG_PATH
 if (-not $LogPath) {
     if ($IsWindows) {
@@ -45,6 +40,11 @@ function Log {
 
 trap {
     Log $_.Exception.Message 'ERROR'
+    exit 1
+}
+
+if ($PSVersionTable.PSVersion.Major -lt 5) {
+    Log 'PowerShell 5.1 or newer is required' 'ERROR'
     exit 1
 }
 


### PR DESCRIPTION
## Summary
- ensure logging helpers are defined before the PowerShell version check
- log version errors using the `Log` function so outdated environments don't fail early

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68668f522b58832abdb388065f6370ca