### PR TITLE
Fix platform detection in install.ps1

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,9 +1,10 @@
 $ErrorActionPreference = 'Stop'
+$isWindows = $env:OS -eq 'Windows_NT'
 Set-StrictMode -Version Latest
 
 $LogPath = $env:SENTINEL_LOG_PATH
 if (-not $LogPath) {
-    if ($IsWindows) {
+    if ($isWindows) {
         $LogPath = Join-Path $env:SystemDrive 'Temp\sentinel.log'
     } else {
         $LogPath = '/var/log/sentinel.log'


### PR DESCRIPTION
## Summary
- detect Windows before enabling strict mode
- switch to `$isWindows` variable

## Testing
- `go vet ./...`
- `go test ./internal/logging ./scripts -run TestInstallPSLog -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686692fd3618832a8c49c13036e5bbc0