### PR TITLE
Add signing step and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,33 @@ wails build -platform linux/amd64
 
 Binaries are written to `build/bin`.
 
+### Signing binaries
+
+1. Run `scripts/install.sh` to install Go, Node.js and the Wails CLI.
+2. Export your GPG key ID in the `SIGN_KEY` environment variable.
+3. Build for your platform with `wails build -platform <target>` or run
+   `scripts/launch.sh`.
+4. Execute `scripts/sign.sh` with the path to each generated binary.
+
+Example commands:
+
+```bash
+export SIGN_KEY=<key-id>               # Linux and macOS
+$Env:SIGN_KEY='<key-id>'               # Windows PowerShell
+scripts/sign.sh build/bin/ai-cli-ui.exe    # Windows
+scripts/sign.sh build/bin/ai-cli-ui.app    # macOS
+scripts/sign.sh build/bin/ai-cli-ui        # Linux
+```
+
+The script creates an ASCII-armored `.asc` file next to each binary.
+Verify a signature with:
+
+```bash
+gpg --verify build/bin/ai-cli-ui.exe.asc build/bin/ai-cli-ui.exe
+```
+
+All signature files remain in `build/bin` alongside the original binaries.
+
 ### Launching
 
 Run the generated binary on your platform:

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -9,7 +9,7 @@ cd "$REPO_ROOT"
 LOG_FILE="${SENTINEL_LOG_PATH:-}"
 if [ -z "$LOG_FILE" ]; then
   case "$(uname -s)" in
-    CYGWIN*|MINGW*|MSYS*) LOG_FILE="$SystemDrive\\Temp\\sentinel.log" ;;
+    CYGWIN*|MINGW*|MSYS*) LOG_FILE="${SystemDrive:-C:}\\Temp\\sentinel.log" ;;
     *) LOG_FILE="/var/log/sentinel.log" ;;
   esac
 fi
@@ -41,6 +41,12 @@ esac
 log "building for $PLATFORM"
 if ! wails build -platform "$PLATFORM" >> "$LOG_FILE" 2>&1; then
   log "wails build failed"
+  exit 1
+fi
+
+log "signing $BIN"
+if ! "$SCRIPT_DIR/sign.sh" "$BIN" >> "$LOG_FILE" 2>&1; then
+  log "signing failed"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- sign build artifacts in `launch.sh`
- document how to sign binaries and verify signatures

## Testing
- `shellcheck scripts/sign.sh scripts/launch.sh`
- `go vet ./...`
- `go test ./...` *(fails: signal interrupt)*
- `npm test --prefix frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a255b076c832ab05310c96376c6fc