### PR TITLE
Add phase plans summary

### DIFF
--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -24,3 +24,17 @@ This dashboard summarizes sprint completion across all phases.
 | 18 | 18 | AI prompt optimization | 📝 Planned |
 
 Progress is tracked per sprint. Phase 08 focuses on final polish and signing binaries.
+
+## Implementation Plan Summary for Phases 010–18
+
+The following overview links each upcoming phase to its task identifiers and corresponding high-level plan. Detailed task lists reside in `docs/plans/Phase_010-018_Implementation_Plan.md`.
+
+- **Phase 010 – OAuth Provider Integration** (`PH010-T01`–`PH010-T50`): implement login flows, token storage, and permission checks across all platforms.
+- **Phase 011 – Service Health Metrics** (`PH011-T01`–`PH011-T50`): collect uptime statistics, expose metrics endpoints, and add alerts for degraded services.
+- **Phase 012 – Advanced Plugin Support** (`PH012-T01`–`PH012-T50`): expand the plugin API for dynamic loading and provide integration examples.
+- **Phase 013 – Voice Command Interface** (`PH013-T01`–`PH013-T50`): integrate speech-to-text libraries and map voice triggers to CLI commands securely.
+- **Phase 014 – Remote Execution Gateway** (`PH014-T01`–`PH014-T50`): implement secure remote execution endpoints with auditing.
+- **Phase 015 – Containerized Deployments** (`PH015-T01`–`PH015-T50`): supply container images, orchestrator scripts, and cross-platform deployment steps.
+- **Phase 016 – Cross-Platform Installer Updates** (`PH016-T01`–`PH016-T50`): refresh installers while preserving backward compatibility.
+- **Phase 017 – Automated Regression Testing** (`PH017-T01`–`PH017-T50`): add end-to-end test suites and integrate them with the CI pipeline.
+- **Phase 018 – AI Prompt Optimization** (`PH018-T01`–`PH018-T50`): tune prompt generation, improve completions, and measure effectiveness.


### PR DESCRIPTION
## Summary
- add short summary for phases 010 through 018 to the dashboard

## Testing
- `go vet ./...`
- `go test ./...` *(fails: command interrupted or no output)*

------
https://chatgpt.com/codex/tasks/task_e_686a2e42660c832a80418b9a66975ab2