### PR TITLE
Sign binaries and document verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,28 +61,32 @@ Binaries are written to `build/bin`.
 
 1. Run `scripts/install.sh` to install Go, Node.js and the Wails CLI.
 2. Export your GPG key ID in the `SIGN_KEY` environment variable.
-3. Build for your platform with `wails build -platform <target>` or run
-   `scripts/launch.sh`.
-4. Execute `scripts/sign.sh` with the path to each generated binary.
+3. Compile for each platform:
 
-Example commands:
+   ```bash
+   wails build -platform windows/amd64
+   wails build -platform darwin/universal
+   wails build -platform linux/amd64
+   ```
+4. Sign the resulting binaries:
 
-```bash
-export SIGN_KEY=<key-id>               # Linux and macOS
-$Env:SIGN_KEY='<key-id>'               # Windows PowerShell
-scripts/sign.sh build/bin/ai-cli-ui.exe    # Windows
-scripts/sign.sh build/bin/ai-cli-ui.app    # macOS
-scripts/sign.sh build/bin/ai-cli-ui        # Linux
-```
+   ```bash
+   export SIGN_KEY=<key-id>               # Linux and macOS
+   $Env:SIGN_KEY='<key-id>'               # Windows PowerShell
+   scripts/sign.sh build/bin/ai-cli-ui.exe \
+                   build/bin/ai-cli-ui.app \
+                   build/bin/ai-cli-ui
+   ```
 
-The script creates an ASCII-armored `.asc` file next to each binary.
-Verify a signature with:
+The script writes ASCII-armored `.asc` files next to each binary in
+`build/bin`. Verify a signature with:
 
 ```bash
 gpg --verify build/bin/ai-cli-ui.exe.asc build/bin/ai-cli-ui.exe
 ```
 
-All signature files remain in `build/bin` alongside the original binaries.
+Repeat the verify step for the macOS and Linux binaries. All signature files are
+stored alongside the artifacts in `build/bin`.
 
 ### Launching
 

--- a/scripts/run_ci.sh
+++ b/scripts/run_ci.sh
@@ -10,3 +10,13 @@ cd "$REPO_ROOT"
 GO_RUN="go run ./cmd/runci"
 
 $GO_RUN
+
+# Build desktop binaries if wails is available
+if command -v wails >/dev/null 2>&1; then
+  wails build -platform windows/amd64
+  wails build -platform darwin/universal
+  wails build -platform linux/amd64
+  "$SCRIPT_DIR/sign.sh" build/bin/*
+else
+  echo "wails CLI not found, skipping UI build" >&2
+fi


### PR DESCRIPTION
## Summary
- sign artifacts in `run_ci.sh` when Wails is present
- document reproducible build and signing steps for all platforms

## Testing
- `shellcheck scripts/run_ci.sh`
- `go vet ./...`
- `go test ./...`
- `timeout 20s bash -c 'scripts/run_ci.sh'` *(fails: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686a2e3edc6c832a887d9328dc2ad33d